### PR TITLE
len of Segments slice should be winsize?

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -173,7 +173,7 @@ func NewMediaPlaylist(winsize uint, capacity uint) (*MediaPlaylist, error) {
 	p.ver = minver
 	p.winsize = winsize
 	p.capacity = capacity
-	p.Segments = make([]*MediaSegment, capacity)
+	p.Segments = make([]*MediaSegment,winsize, capacity)
 	return p, nil
 }
 


### PR DESCRIPTION
... and cap of Segments  should by capacity?
Otherwise it how does one know how large Segments is ahead of time without having to write a procedure to look for non-nil elements.

Or else winsize could be an exported entity
