### PR TITLE
Adding quotes to URI to make the external API nicer.

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -357,8 +357,9 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 			p.buf.WriteString("#EXT-X-KEY:")
 			p.buf.WriteString("METHOD=")
 			p.buf.WriteString(seg.Key.Method)
-			p.buf.WriteString(",URI=")
+			p.buf.WriteString(",URI=\"")
 			p.buf.WriteString(seg.Key.URI)
+			p.buf.WriteRune('"')
 			if seg.Key.IV != "" {
 				p.buf.WriteString(",IV=")
 				p.buf.WriteString(seg.Key.IV)


### PR DESCRIPTION
From my initial testing I ran into a issue where the URI was missing quotes, in other places the library adds quotes for you.