### PR TITLE
Fixed Audio group name being incorrectly set to the Video group name

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -57,7 +57,7 @@ func (p *MasterPlaylist) Append(uri string, chunklist *MediaPlaylist, params Var
 	v.VariantParams = params
 	p.Variants = append(p.Variants, v)
 	if len(v.Alternatives) > 0 {
-		version(&p.ver, 4) // As per 3.3.9
+		p.ver = 4 // As per 3.3.9
 	}
 	p.buf.Reset()
 }
@@ -165,9 +165,8 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 				p.buf.WriteRune('"')
 			}
 			if pl.Resolution != "" {
-				p.buf.WriteString(",RESOLUTION=\"")
+				p.buf.WriteString(",RESOLUTION=") // Resolution should not be quoted
 				p.buf.WriteString(pl.Resolution)
-				p.buf.WriteRune('"')
 			}
 			if pl.Audio != "" {
 				p.buf.WriteString(",AUDIO=\"")

--- a/writer.go
+++ b/writer.go
@@ -106,6 +106,11 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 					p.buf.WriteString(alt.Autoselect)
 					p.buf.WriteRune('"')
 				}
+				if alt.Language != "" {
+					p.buf.WriteString(",LANGUAGE=\"")
+					p.buf.WriteString(alt.Language)
+					p.buf.WriteRune('"')
+				}
 				if alt.Forced != "" {
 					p.buf.WriteString(",FORCED=\"")
 					p.buf.WriteString(alt.Forced)

--- a/writer.go
+++ b/writer.go
@@ -56,6 +56,9 @@ func (p *MasterPlaylist) Append(uri string, chunklist *MediaPlaylist, params Var
 	v.Chunklist = chunklist
 	v.VariantParams = params
 	p.Variants = append(p.Variants, v)
+	if len(p.Variants.Alternatives) > 0 {
+		version(&p.ver, 4) // As per 3.3.9
+	}
 	p.buf.Reset()
 }
 
@@ -137,9 +140,8 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 				p.buf.WriteRune('"')
 			}
 			if pl.Resolution != "" {
-				p.buf.WriteString(",RESOLUTION=\"")
+				p.buf.WriteString(",RESOLUTION=") // Resolution should not be quoted
 				p.buf.WriteString(pl.Resolution)
-				p.buf.WriteRune('"')
 			}
 			if pl.Video != "" {
 				p.buf.WriteString(",VIDEO=\"")

--- a/writer.go
+++ b/writer.go
@@ -81,9 +81,8 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 			for _, alt := range pl.Alternatives {
 				p.buf.WriteString("#EXT-X-MEDIA:")
 				if alt.Type != "" {
-					p.buf.WriteString("TYPE=\"")
+					p.buf.WriteString("TYPE=") // Type should not be quoted
 					p.buf.WriteString(alt.Type)
-					p.buf.WriteRune('"')
 				}
 				if alt.GroupId != "" {
 					p.buf.WriteString(",GROUP-ID=\"")

--- a/writer.go
+++ b/writer.go
@@ -56,7 +56,7 @@ func (p *MasterPlaylist) Append(uri string, chunklist *MediaPlaylist, params Var
 	v.Chunklist = chunklist
 	v.VariantParams = params
 	p.Variants = append(p.Variants, v)
-	if len(p.Variants.Alternatives) > 0 {
+	if len(v.Alternatives) > 0 {
 		version(&p.ver, 4) // As per 3.3.9
 	}
 	p.buf.Reset()

--- a/writer.go
+++ b/writer.go
@@ -101,9 +101,8 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 					p.buf.WriteString("NO")
 				}
 				if alt.Autoselect != "" {
-					p.buf.WriteString(",AUTOSELECT=\"")
+					p.buf.WriteString(",AUTOSELECT=")
 					p.buf.WriteString(alt.Autoselect)
-					p.buf.WriteRune('"')
 				}
 				if alt.Language != "" {
 					p.buf.WriteString(",LANGUAGE=\"")

--- a/writer.go
+++ b/writer.go
@@ -169,7 +169,7 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 			}
 			if pl.Audio != "" {
 				p.buf.WriteString(",AUDIO=\"")
-				p.buf.WriteString(pl.Video)
+				p.buf.WriteString(pl.Audio)
 				p.buf.WriteRune('"')
 			}
 			if pl.Video != "" {
@@ -474,7 +474,7 @@ func (p *MediaPlaylist) DurationAsInt(yes bool) {
 }
 
 // Count tells us the number of items that are currently in the media playlist
-func (p *MediaPlaylist) Count() (uint) {
+func (p *MediaPlaylist) Count() uint {
 	return p.count
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -351,6 +351,37 @@ func TestNewMasterPlaylist(t *testing.T) {
 	m.Append("chunklist1.m3u8", p, VariantParams{})
 }
 
+// Create new master playlist without params
+// Add media playlist with Alternatives
+func TestNewMasterPlaylistWithAlternatives(t *testing.T) {
+	m := NewMasterPlaylist()
+	audioUri := fmt.Sprintf("%s/rendition.m3u8", "800")
+	audioAlt := &Alternative{
+		GroupId:    "audio",
+		URI:        audioUri,
+		Type:       "AUDIO",
+		Name:       "main",
+		Default:    true,
+		Autoselect: "YES",
+		Language:   "english",
+	}
+	p, e := NewMediaPlaylist(3, 5)
+	if e != nil {
+		t.Fatalf("Create media playlist failed: %s", e)
+	}
+	for i := 0; i < 5; i++ {
+		e = p.Append(fmt.Sprintf("test%d.ts", i), 5.0, "")
+		if e != nil {
+			t.Errorf("Add segment #%d to a media playlist failed: %s", i, e)
+		}
+	}
+	m.Append("chunklist1.m3u8", p, VariantParams{Alternatives: []*Alternative{audioAlt}})
+
+	if m.ver != 4 {
+		t.Fatalf("Expected version 4, actual, %d", m.ver)
+	}
+}
+
 // Create new master playlist with params
 // Add media playlist
 func TestNewMasterPlaylistWithParams(t *testing.T) {
@@ -423,8 +454,8 @@ func ExampleMasterPlaylist_String() {
 	// Output:
 	// #EXTM3U
 	// #EXT-X-VERSION:3
-	// #EXT-X-STREAM-INF:PROGRAM-ID=123,BANDWIDTH=1500000,RESOLUTION="576x480"
+	// #EXT-X-STREAM-INF:PROGRAM-ID=123,BANDWIDTH=1500000,RESOLUTION=576x480
 	// chunklist1.m3u8
-	// #EXT-X-STREAM-INF:PROGRAM-ID=123,BANDWIDTH=1500000,RESOLUTION="576x480"
+	// #EXT-X-STREAM-INF:PROGRAM-ID=123,BANDWIDTH=1500000,RESOLUTION=576x480
 	// chunklist2.m3u8
 }


### PR DESCRIPTION
Fixed a bug where the Audio group was not being set using the Audio variable on the VariantParams, it was instead using the video group name.

The change to the Count() method was done automatically by go fmt, which my IDE runs on every save.