### PR TITLE
Fix alt duplicates

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -87,6 +87,7 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 				if altsWritten[altKey] {
 					continue
 				}
+				altsWritten[altKey] = true
 
 				p.buf.WriteString("#EXT-X-MEDIA:")
 				if alt.Type != "" {

--- a/writer.go
+++ b/writer.go
@@ -25,6 +25,7 @@ package m3u8
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math"
 	"strconv"
 	"time"
@@ -76,9 +77,17 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 	p.buf.WriteString(strver(p.ver))
 	p.buf.WriteRune('\n')
 
+	var altsWritten map[string]bool = make(map[string]bool)
+
 	for _, pl := range p.Variants {
 		if pl.Alternatives != nil {
 			for _, alt := range pl.Alternatives {
+				// Make sure that we only write out an alternative once
+				altKey := fmt.Sprintf("%s-%s-%s-%s", alt.Type, alt.GroupId, alt.Name, alt.Language)
+				if altsWritten[altKey] {
+					continue
+				}
+
 				p.buf.WriteString("#EXT-X-MEDIA:")
 				if alt.Type != "" {
 					p.buf.WriteString("TYPE=") // Type should not be quoted


### PR DESCRIPTION
Currently if the same group is referenced multiple times, it will appear multiple times in the HLS output which is incorrect.

This change keeps track of this and will only write out the same group (currently by composing a composite key of type, group Id, Name * Language) once.