### PR TITLE
Produce the SUBTITLES attribute for EXT-X-STREAM-INF entries

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -199,6 +199,11 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 				p.buf.WriteString(pl.Video)
 				p.buf.WriteRune('"')
 			}
+			if pl.Subtitles != "" {
+				p.buf.WriteString(",SUBTITLES=\"")
+				p.buf.WriteString(pl.Subtitles)
+				p.buf.WriteRune('"')
+			}
 			p.buf.WriteRune('\n')
 			p.buf.WriteString(pl.URI)
 			if p.Args != "" {


### PR DESCRIPTION
The HLS specification allows for a SUBTITLES attribute to be set on EXT-X-STREAM-INF entries:
https://tools.ietf.org/html/draft-pantos-http-live-streaming-16#section-4.3.4.2

This pull-request causes the SUBTITLES attribute to be set if the variant has the Subtitles field set on the struct.