### PR TITLE
Fix playlist version in SetKey method

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -541,7 +541,14 @@ func (p *MediaPlaylist) SetKey(method, uri, iv, keyformat, keyformatversions str
 	if p.count == 0 {
 		return errors.New("playlist is empty")
 	}
-	version(&p.ver, 5) // due section 7
+
+	// A Media Playlist MUST indicate a EXT-X-VERSION of 5 or higher if it
+	// contains:
+	//   - The KEYFORMAT and KEYFORMATVERSIONS attributes of the EXT-X-KEY tag.
+	if keyformat != "" && keyformatversions != "" {
+		version(&p.ver, 5)
+	}
+
 	p.Segments[(p.tail-1)%p.capacity].Key = &Key{method, uri, iv, keyformat, keyformatversions}
 	return nil
 }


### PR DESCRIPTION
Сейчас при вызове ```playlist.SetKey("AES-128", KeyUrl, "", "", "")``` у плейлиста будет версия 5, хотя должна быть 3.

В стандарте есть требование к версии медиа плейлиста для шифрованного HLS:
```
A Media Playlist MUST indicate a EXT-X-VERSION of 5 or higher if it contains:
   - The KEYFORMAT and KEYFORMATVERSIONS attributes of the EXT-X-KEY tag.
```

Т.е. 5-я версия должна быть *только* если присутствуют атрибуты KEYFORMAT и KEYFORMATVERSIONS.

 
