### PR TITLE
Fixed unnecessary playlist version change in SetDefaultKey

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -516,9 +516,16 @@ func (p *MediaPlaylist) Close() {
 // Set encryption key appeared once in header of the playlist (pointer to MediaPlaylist.Key).
 // It useful when keys not changed during playback.
 // Set tag for the whole list.
-func (p *MediaPlaylist) SetDefaultKey(method, uri, iv, keyformat, keyformatversions string) {
-	version(&p.ver, 5) // due section 7
+func (p *MediaPlaylist) SetDefaultKey(method, uri, iv, keyformat, keyformatversions string) error {
+	// A Media Playlist MUST indicate a EXT-X-VERSION of 5 or higher if it
+	// contains:
+	//   - The KEYFORMAT and KEYFORMATVERSIONS attributes of the EXT-X-KEY tag.
+	if keyformat != "" && keyformatversions != "" {
+		version(&p.ver, 5)
+	}
 	p.Key = &Key{method, uri, iv, keyformat, keyformatversions}
+
+	return nil
 }
 
 // Set map appeared once in header of the playlist (pointer to MediaPlaylist.Key).

--- a/writer_test.go
+++ b/writer_test.go
@@ -173,6 +173,33 @@ func TestSetKeyForMediaPlaylist(t *testing.T) {
 
 // Create new media playlist
 // Add segment to media playlist
+// Set encryption key
+func TestSetDefaultKeyForMediaPlaylist(t *testing.T) {
+	p, e := NewMediaPlaylist(3, 5)
+	if e != nil {
+		t.Fatalf("Create media playlist failed: %s", e)
+	}
+	e = p.SetDefaultKey("AES-128", "https://example.com", "iv", "", "")
+	if e != nil {
+		t.Errorf("Set default key to a media playlist failed: %s", e)
+	}
+	if p.ver != 3 {
+		t.Errorf("SetDefaultKey to a media playlist changed version unnecessarily")
+	}
+
+	// Test that using V5 features updates EXT-X-VERSION
+	e = p.SetDefaultKey("AES-128", "https://example.com", "iv", "format", "vers")
+	if e != nil {
+		t.Errorf("Set key to a media playlist failed: %s", e)
+	}
+	if p.ver != 5 {
+		t.Errorf("SetDefaultKey did not update version")
+	}
+
+}
+
+// Create new media playlist
+// Add segment to media playlist
 // Set map
 func TestSetMapForMediaPlaylist(t *testing.T) {
 	p, e := NewMediaPlaylist(3, 5)


### PR DESCRIPTION
As defined in the HLS  V5 spec:
>   A Playlist MUST indicate protocol version 5 or higher if it contains:
   o  The KEYFORMAT and KEYFORMATVERSIONS attributes of the EXT-X-KEY
      tag.

However any HLS version > 2 is compatible with EXT-X-KEY tags containing only METHOD, URI and IV attributes.

It looks like this behaviour was fixed for the `SetKey` function, but not `SetDefaultKey`. I added the fix to `SetDefaultKey` and a couple of tests around it.

I also changed the behaviour of `SetDefaultKey` to return an `error` value to make it more resemble `SetKey`