### PR TITLE
Append Args if playlist already has query params

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -208,7 +209,11 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 			p.buf.WriteRune('\n')
 			p.buf.WriteString(pl.URI)
 			if p.Args != "" {
-				p.buf.WriteRune('?')
+				if strings.Contains(pl.URI, "?") {
+					p.buf.WriteRune('&')
+				} else {
+					p.buf.WriteRune('?')
+				}
 				p.buf.WriteString(p.Args)
 			}
 			p.buf.WriteRune('\n')

--- a/writer_test.go
+++ b/writer_test.go
@@ -23,6 +23,7 @@ package m3u8
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -425,6 +426,28 @@ func TestNewMasterPlaylistWithParams(t *testing.T) {
 		}
 	}
 	m.Append("chunklist1.m3u8", p, VariantParams{ProgramId: 123, Bandwidth: 1500000, Resolution: "576x480"})
+}
+
+// Create new master playlist
+// Add media playlist with existing query params in URI
+// Append more query params and ensure it encodes correctly
+func TestEncodeMasterPlaylistWithExistingQuery(t *testing.T) {
+	m := NewMasterPlaylist()
+	p, e := NewMediaPlaylist(3, 5)
+	if e != nil {
+		t.Fatalf("Create media playlist failed: %s", e)
+	}
+	for i := 0; i < 5; i++ {
+		e = p.Append(fmt.Sprintf("test%d.ts", i), 5.0, "")
+		if e != nil {
+			t.Errorf("Add segment #%d to a media playlist failed: %s", i, e)
+		}
+	}
+	m.Append("chunklist1.m3u8?k1=v1&k2=v2", p, VariantParams{ProgramId: 123, Bandwidth: 1500000, Resolution: "576x480"})
+	m.Args = "k3=v3"
+	if !strings.Contains(m.String(), "chunklist1.m3u8?k1=v1&k2=v2&k3=v3\n") {
+		t.Errorf("Encode master with existing args failed")
+	}
 }
 
 // Create new master playlist


### PR DESCRIPTION
Previously media playlists were assumed to have no query parameters when
encoding a master manifest with Args. This commit first checks if the
URI contains existing params (checks for "?") and if so, appends new
Args with a leading "&", else it will add "?".