### PR TITLE
Use segment Keyformat and Keyformatversions on MediaPlaylist.Encode()

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -454,14 +454,14 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 				p.buf.WriteString(",IV=")
 				p.buf.WriteString(seg.Key.IV)
 			}
-			if p.Key.Keyformat != "" {
+			if seg.Key.Keyformat != "" {
 				p.buf.WriteString(",KEYFORMAT=\"")
-				p.buf.WriteString(p.Key.Keyformat)
+				p.buf.WriteString(seg.Key.Keyformat)
 				p.buf.WriteRune('"')
 			}
-			if p.Key.Keyformatversions != "" {
+			if seg.Key.Keyformatversions != "" {
 				p.buf.WriteString(",KEYFORMATVERSIONS=\"")
-				p.buf.WriteString(p.Key.Keyformatversions)
+				p.buf.WriteString(seg.Key.Keyformatversions)
 				p.buf.WriteRune('"')
 			}
 			p.buf.WriteRune('\n')


### PR DESCRIPTION
Previously, when a segment has different encryption parameters than the
default playlist, the Encode() function uses the segment's parameters for
all parameters but `Keyformat` and `Keyformatversions`.

This change uses the segment's `Keyformat` and `Keyformatversions` when the
segments are encoded, allowing these parameters to change per segment and
not requiring a playlist to have a key set.

An `Encode()` at the end of the `TestSetKeyForMediaPlaylist` test would show a nil pointer exception, as the playlist did not have a key initialised, but the Encode() function would try and access it anyway.