### PR TITLE
Increment pls version when either KEYFORMAT or KEYFORMATVERSIONS is set

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -551,7 +551,7 @@ func (p *MediaPlaylist) SetDefaultKey(method, uri, iv, keyformat, keyformatversi
 	// A Media Playlist MUST indicate a EXT-X-VERSION of 5 or higher if it
 	// contains:
 	//   - The KEYFORMAT and KEYFORMATVERSIONS attributes of the EXT-X-KEY tag.
-	if keyformat != "" && keyformatversions != "" {
+	if keyformat != "" || keyformatversions != "" {
 		version(&p.ver, 5)
 	}
 	p.Key = &Key{method, uri, iv, keyformat, keyformatversions}
@@ -583,7 +583,7 @@ func (p *MediaPlaylist) SetKey(method, uri, iv, keyformat, keyformatversions str
 	// A Media Playlist MUST indicate a EXT-X-VERSION of 5 or higher if it
 	// contains:
 	//   - The KEYFORMAT and KEYFORMATVERSIONS attributes of the EXT-X-KEY tag.
-	if keyformat != "" && keyformatversions != "" {
+	if keyformat != "" || keyformatversions != "" {
 		version(&p.ver, 5)
 	}
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -159,17 +159,31 @@ func TestOverAddSegmentsToMediaPlaylist(t *testing.T) {
 // Add segment to media playlist
 // Set encryption key
 func TestSetKeyForMediaPlaylist(t *testing.T) {
-	p, e := NewMediaPlaylist(3, 5)
-	if e != nil {
-		t.Fatalf("Create media playlist failed: %s", e)
+	tests := []struct {
+		KeyFormat         string
+		KeyFormatVersions string
+		ExpectVersion     uint8
+	}{
+		{"", "", 3},
+		{"Format", "", 5},
+		{"", "Version", 5},
+		{"Format", "Version", 5},
 	}
-	e = p.Append("test01.ts", 5.0, "")
-	if e != nil {
-		t.Errorf("Add 1st segment to a media playlist failed: %s", e)
-	}
-	e = p.SetKey("AES-128", "https://example.com", "iv", "format", "vers")
-	if e != nil {
-		t.Errorf("Set key to a media playlist failed: %s", e)
+
+	for _, test := range tests {
+		p, e := NewMediaPlaylist(3, 5)
+		if e != nil {
+			t.Fatalf("Create media playlist failed: %s", e)
+		}
+		if e = p.Append("test01.ts", 5.0, ""); e != nil {
+			t.Errorf("Add 1st segment to a media playlist failed: %s", e)
+		}
+		if e := p.SetKey("AES-128", "https://example.com", "iv", test.KeyFormat, test.KeyFormatVersions); e != nil {
+			t.Errorf("Set key to a media playlist failed: %s", e)
+		}
+		if p.ver != test.ExpectVersion {
+			t.Errorf("Set key playlist version: %v, expected: %v", p.ver, test.ExpectVersion)
+		}
 	}
 }
 
@@ -177,27 +191,29 @@ func TestSetKeyForMediaPlaylist(t *testing.T) {
 // Add segment to media playlist
 // Set encryption key
 func TestSetDefaultKeyForMediaPlaylist(t *testing.T) {
-	p, e := NewMediaPlaylist(3, 5)
-	if e != nil {
-		t.Fatalf("Create media playlist failed: %s", e)
-	}
-	e = p.SetDefaultKey("AES-128", "https://example.com", "iv", "", "")
-	if e != nil {
-		t.Errorf("Set default key to a media playlist failed: %s", e)
-	}
-	if p.ver != 3 {
-		t.Errorf("SetDefaultKey to a media playlist changed version unnecessarily")
-	}
-
-	// Test that using V5 features updates EXT-X-VERSION
-	e = p.SetDefaultKey("AES-128", "https://example.com", "iv", "format", "vers")
-	if e != nil {
-		t.Errorf("Set key to a media playlist failed: %s", e)
-	}
-	if p.ver != 5 {
-		t.Errorf("SetDefaultKey did not update version")
+	tests := []struct {
+		KeyFormat         string
+		KeyFormatVersions string
+		ExpectVersion     uint8
+	}{
+		{"", "", 3},
+		{"Format", "", 5},
+		{"", "Version", 5},
+		{"Format", "Version", 5},
 	}
 
+	for _, test := range tests {
+		p, e := NewMediaPlaylist(3, 5)
+		if e != nil {
+			t.Fatalf("Create media playlist failed: %s", e)
+		}
+		if e := p.SetDefaultKey("AES-128", "https://example.com", "iv", test.KeyFormat, test.KeyFormatVersions); e != nil {
+			t.Errorf("Set key to a media playlist failed: %s", e)
+		}
+		if p.ver != test.ExpectVersion {
+			t.Errorf("Set key playlist version: %v, expected: %v", p.ver, test.ExpectVersion)
+		}
+	}
 }
 
 // Create new media playlist


### PR DESCRIPTION
HLS draft RFC (draft-pantos-http-live-streaming-18) section 4.3.2.4
states that the use of KEYFORMAT REQUIRES playlist version 5 or
greater, and also state the use of KEYFORMATVERSIONS requires playlist
version 5 or greater.

Section 7 then states version 5 is required if "The KEYFORMAT and
KEYFORMATVERSIONS attributes of the EXT-X-KEY tag.",

Currently the version number is incremented only if both options are set.

As some devices set one to its default value and omit the other, the
playlist should increment the version number if either of these options
are set.