### PR TITLE
Support EXT-X-SCTE when encoding playlists

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -449,6 +449,22 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 		if p.winsize > 0 { // skip for VOD playlists, where winsize = 0
 			i++
 		}
+		if seg.SCTE != nil {
+			p.buf.WriteString("#EXT-SCTE:")
+			p.buf.WriteString("CUE=\"")
+			p.buf.WriteString(seg.SCTE.Cue)
+			p.buf.WriteRune('"')
+			if seg.SCTE.ID != "" {
+				p.buf.WriteString(",ID=\"")
+				p.buf.WriteString(seg.SCTE.ID)
+				p.buf.WriteRune('"')
+			}
+			if seg.SCTE.Time != 0 {
+				p.buf.WriteString(",TIME=")
+				p.buf.WriteString(strconv.FormatFloat(seg.SCTE.Time, 'f', -1, 64))
+			}
+			p.buf.WriteRune('\n')
+		}
 		// check for key change
 		if seg.Key != nil && p.Key != seg.Key {
 			p.buf.WriteString("#EXT-X-KEY:")

--- a/writer_test.go
+++ b/writer_test.go
@@ -157,6 +157,40 @@ func TestOverAddSegmentsToMediaPlaylist(t *testing.T) {
 
 // Create new media playlist
 // Add segment to media playlist
+// Set SCTE
+func TestSetSCTEForMediaPlaylist(t *testing.T) {
+	tests := []struct {
+		Cue      string
+		ID       string
+		Time     float64
+		Expected string
+	}{
+		{"CueData1", "", 0, `#EXT-SCTE:CUE="CueData1"` + "\n"},
+		{"CueData2", "ID2", 0, `#EXT-SCTE:CUE="CueData2",ID="ID2"` + "\n"},
+		{"CueData3", "ID3", 3.141, `#EXT-SCTE:CUE="CueData3",ID="ID3",TIME=3.141` + "\n"},
+		{"CueData4", "", 3.1, `#EXT-SCTE:CUE="CueData4",TIME=3.1` + "\n"},
+		{"CueData5", "", 3.0, `#EXT-SCTE:CUE="CueData5",TIME=3` + "\n"},
+	}
+
+	for _, test := range tests {
+		p, e := NewMediaPlaylist(1, 1)
+		if e != nil {
+			t.Fatalf("Create media playlist failed: %s", e)
+		}
+		if e = p.Append("test01.ts", 5.0, ""); e != nil {
+			t.Errorf("Add 1st segment to a media playlist failed: %s", e)
+		}
+		if e := p.SetSCTE(test.Cue, test.ID, test.Time); e != nil {
+			t.Errorf("SetSCTE to a media playlist failed: %s", e)
+		}
+		if !strings.Contains(p.String(), test.Expected) {
+			t.Errorf("Test %+v did not contain: %q, playlist: %v", test, test.Expected, p.String())
+		}
+	}
+}
+
+// Create new media playlist
+// Add segment to media playlist
 // Set encryption key
 func TestSetKeyForMediaPlaylist(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Expands upon #40 to support encoding the SCTE segments into a playlist.

Such that the following:
```
package main

import (
        "fmt"

        "github.com/grafov/m3u8"
)

func main() {
        p, _ := m3u8.NewMediaPlaylist(1, 1)
        _ = p.Append("test01.ts", 5.0, "")
        _ = p.SetSCTE("CueData", "ID", 3.141)
        fmt.Print(p.String())
}
```

Outputs:
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-TARGETDURATION:5
#EXT-X-SCTE:CUE="CueData",ID="ID",TIME=3.141
#EXTINF:5.000,
test01.ts
```