### PR TITLE
Expose master and media playlist version setter and getter methods

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -232,6 +232,17 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 	return &p.buf
 }
 
+// Version returns the current playlist version number
+func (p *MasterPlaylist) Version() uint8 {
+	return p.ver
+}
+
+// SetVersion sets the playlist version number, note the version maybe changed
+// automatically by other Set methods.
+func (p *MasterPlaylist) SetVersion(ver uint8) {
+	p.ver = ver
+}
+
 // For compatibility with Stringer interface
 // For example fmt.Printf("%s", sampleMediaList) will encode
 // playist and print its string representation.
@@ -674,4 +685,15 @@ func (p *MediaPlaylist) SetProgramDateTime(value time.Time) error {
 	}
 	p.Segments[p.last()].ProgramDateTime = value
 	return nil
+}
+
+// Version returns the current playlist version number
+func (p *MediaPlaylist) Version() uint8 {
+	return p.ver
+}
+
+// SetVersion sets the playlist version number, note the version maybe changed
+// automatically by other Set methods.
+func (p *MediaPlaylist) SetVersion(ver uint8) {
+	p.ver = ver
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -434,6 +434,23 @@ func TestClosedMediaPlaylist(t *testing.T) {
 	p.Close()
 }
 
+func TestMediaVersion(t *testing.T) {
+	m, _ := NewMediaPlaylist(3, 3)
+	m.ver = 5
+	if m.Version() != m.ver {
+		t.Errorf("Expected version: %v, got: %v", m.ver, m.Version())
+	}
+}
+
+func TestMediaSetVersion(t *testing.T) {
+	m, _ := NewMediaPlaylist(3, 3)
+	m.ver = 3
+	m.SetVersion(5)
+	if m.ver != 5 {
+		t.Errorf("Expected version: %v, got: %v", 5, m.ver)
+	}
+}
+
 // Create new master playlist without params
 // Add media playlist
 func TestNewMasterPlaylist(t *testing.T) {
@@ -560,6 +577,23 @@ func TestEncodeMasterPlaylistWithStreamInfName(t *testing.T) {
 	}
 	if !strings.Contains(m.String(), "NAME=\"HD 960p\"") {
 		t.Fatalf("Encode master with Name in EXT-X-STREAM-INF failed")
+	}
+}
+
+func TestMasterVersion(t *testing.T) {
+	m := NewMasterPlaylist()
+	m.ver = 5
+	if m.Version() != m.ver {
+		t.Errorf("Expected version: %v, got: %v", m.ver, m.Version())
+	}
+}
+
+func TestMasterSetVersion(t *testing.T) {
+	m := NewMasterPlaylist()
+	m.ver = 3
+	m.SetVersion(5)
+	if m.ver != 5 {
+		t.Errorf("Expected version: %v, got: %v", 5, m.ver)
 	}
 }
 


### PR DESCRIPTION
Currently version is controlled via private version functions and
set via the Set* methods when required. This is the ideal method for
most applications, as the version is managed by the library

This change provides the user the ability to check the version as
well as overwrite it, as during some live streams the version number
may have been incremented via the Set methods, but once those
segments have been removed the version number will change during
playback. This isn't ideal as the player may encounter version changes
during playback to versions it doesn't support. This provides
implementors the ability to announce up front what the version number
will be.