### PR TITLE
Hori improvements - Alternative approach

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -355,14 +355,18 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 	case !state.tagInf && strings.HasPrefix(line, "#EXTINF:"):
 		state.tagInf = true
 		state.listType = MEDIA
-		params := strings.SplitN(line[8:], ",", 2)
-		if len(params) > 0 {
-			if state.duration, err = strconv.ParseFloat(params[0], 64); strict && err != nil {
+		sepIndex := strings.Index(line, ",")
+		if sepIndex == -1 {
+			break
+		}
+		duration := line[8:sepIndex]
+		if len(duration) > 0 {
+			if state.duration, err = strconv.ParseFloat(duration, 64); strict && err != nil {
 				return fmt.Errorf("Duration parsing error: %s", err)
 			}
 		}
-		if len(params) > 1 {
-			state.title = params[1]
+		if len(line) > sepIndex {
+			state.title = line[sepIndex+1:]
 		}
 	case !strings.HasPrefix(line, "#"):
 		if state.tagInf {

--- a/reader.go
+++ b/reader.go
@@ -352,6 +352,68 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 
 	line = strings.TrimSpace(line)
 	switch {
+	case !state.tagInf && strings.HasPrefix(line, "#EXTINF:"):
+		state.tagInf = true
+		state.listType = MEDIA
+		params := strings.SplitN(line[8:], ",", 2)
+		if len(params) > 0 {
+			if state.duration, err = strconv.ParseFloat(params[0], 64); strict && err != nil {
+				return fmt.Errorf("Duration parsing error: %s", err)
+			}
+		}
+		if len(params) > 1 {
+			state.title = params[1]
+		}
+	case !strings.HasPrefix(line, "#"):
+		if state.tagInf {
+			p.Append(line, state.duration, state.title)
+			state.tagInf = false
+		}
+		if state.tagRange {
+			if err = p.SetRange(state.limit, state.offset); strict && err != nil {
+				return err
+			}
+			state.tagRange = false
+		}
+		if state.tagSCTE35 {
+			state.tagSCTE35 = false
+			scte := *state.scte
+			if err = p.SetSCTE(scte.Cue, scte.ID, scte.Time); strict && err != nil {
+				return err
+			}
+		}
+		if state.tagDiscontinuity {
+			state.tagDiscontinuity = false
+			if err = p.SetDiscontinuity(); strict && err != nil {
+				return err
+			}
+		}
+		if state.tagProgramDateTime {
+			state.tagProgramDateTime = false
+			if err = p.SetProgramDateTime(state.programDateTime); strict && err != nil {
+				return err
+			}
+		}
+		// If EXT-X-KEY appeared before reference to segment (EXTINF) then it linked to this segment
+		if state.tagKey {
+			p.Segments[p.last()].Key = &Key{state.xkey.Method, state.xkey.URI, state.xkey.IV, state.xkey.Keyformat, state.xkey.Keyformatversions}
+			// First EXT-X-KEY may appeared in the header of the playlist and linked to first segment
+			// but for convenient playlist generation it also linked as default playlist key
+			if p.Key == nil {
+				p.Key = state.xkey
+			}
+			state.tagKey = false
+		}
+		// If EXT-X-MAP appeared before reference to segment (EXTINF) then it linked to this segment
+		if state.tagMap {
+			p.Segments[p.last()].Map = &Map{state.xmap.URI, state.xmap.Limit, state.xmap.Offset}
+			// First EXT-X-MAP may appeared in the header of the playlist and linked to first segment
+			// but for convenient playlist generation it also linked as default playlist map
+			if p.Map == nil {
+				p.Map = state.xmap
+			}
+			state.tagMap = false
+		}
 	// start tag first
 	case line == "#EXTM3U":
 		state.m3u = true
@@ -454,74 +516,12 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 				state.scte.Time, _ = strconv.ParseFloat(value, 64)
 			}
 		}
-	case !state.tagInf && strings.HasPrefix(line, "#EXTINF:"):
-		state.tagInf = true
-		state.listType = MEDIA
-		params := strings.SplitN(line[8:], ",", 2)
-		if len(params) > 0 {
-			if state.duration, err = strconv.ParseFloat(params[0], 64); strict && err != nil {
-				return fmt.Errorf("Duration parsing error: %s", err)
-			}
-		}
-		if len(params) > 1 {
-			state.title = params[1]
-		}
 	case !state.tagDiscontinuity && strings.HasPrefix(line, "#EXT-X-DISCONTINUITY"):
 		state.tagDiscontinuity = true
 		state.listType = MEDIA
 	case strings.HasPrefix(line, "#EXT-X-I-FRAMES-ONLY"):
 		state.listType = MEDIA
 		p.Iframe = true
-	case !strings.HasPrefix(line, "#"):
-		if state.tagInf {
-			p.Append(line, state.duration, state.title)
-			state.tagInf = false
-		}
-		if state.tagRange {
-			if err = p.SetRange(state.limit, state.offset); strict && err != nil {
-				return err
-			}
-			state.tagRange = false
-		}
-		if state.tagSCTE35 {
-			state.tagSCTE35 = false
-			scte := *state.scte
-			if err = p.SetSCTE(scte.Cue, scte.ID, scte.Time); strict && err != nil {
-				return err
-			}
-		}
-		if state.tagDiscontinuity {
-			state.tagDiscontinuity = false
-			if err = p.SetDiscontinuity(); strict && err != nil {
-				return err
-			}
-		}
-		if state.tagProgramDateTime {
-			state.tagProgramDateTime = false
-			if err = p.SetProgramDateTime(state.programDateTime); strict && err != nil {
-				return err
-			}
-		}
-		// If EXT-X-KEY appeared before reference to segment (EXTINF) then it linked to this segment
-		if state.tagKey {
-			p.Segments[p.last()].Key = &Key{state.xkey.Method, state.xkey.URI, state.xkey.IV, state.xkey.Keyformat, state.xkey.Keyformatversions}
-			// First EXT-X-KEY may appeared in the header of the playlist and linked to first segment
-			// but for convenient playlist generation it also linked as default playlist key
-			if p.Key == nil {
-				p.Key = state.xkey
-			}
-			state.tagKey = false
-		}
-		// If EXT-X-MAP appeared before reference to segment (EXTINF) then it linked to this segment
-		if state.tagMap {
-			p.Segments[p.last()].Map = &Map{state.xmap.URI, state.xmap.Limit, state.xmap.Offset}
-			// First EXT-X-MAP may appeared in the header of the playlist and linked to first segment
-			// but for convenient playlist generation it also linked as default playlist map
-			if p.Map == nil {
-				p.Map = state.xmap
-			}
-			state.tagMap = false
-		}
 	case strings.HasPrefix(line, "#WV-AUDIO-CHANNELS"):
 		state.listType = MEDIA
 		if _, err = fmt.Sscanf(line, "#WV-AUDIO-CHANNELS %d", &wv.AudioChannels); strict && err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -359,3 +359,36 @@ func TestMediaPlaylistWithSCTE35Tag(t *testing.T) {
 		}
 	}
 }
+
+/****************
+ *  Benchmarks  *
+ ****************/
+
+func BenchmarkDecodeMasterPlaylist(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f, err := os.Open("sample-playlists/master.m3u8")
+		if err != nil {
+			b.Fatal(err)
+		}
+		p := NewMasterPlaylist()
+		if err := p.DecodeFrom(bufio.NewReader(f), false); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecodeMediaPlaylist(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		f, err := os.Open("sample-playlists/wowza-vod-chunklist.m3u8")
+		if err != nil {
+			b.Fatal(err)
+		}
+		p, err := NewMediaPlaylist(50000, 50000)
+		if err != nil {
+			b.Fatalf("Create media playlist failed: %s", err)
+		}
+		if err = p.DecodeFrom(bufio.NewReader(f), true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -543,13 +543,13 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 		}
 		p.buf.WriteRune(',')
 		p.buf.WriteString(seg.Title)
-		p.buf.WriteString("\n")
+		p.buf.WriteRune('\n')
 		p.buf.WriteString(seg.URI)
 		if p.Args != "" {
 			p.buf.WriteRune('?')
 			p.buf.WriteString(p.Args)
 		}
-		p.buf.WriteString("\n")
+		p.buf.WriteRune('\n')
 	}
 	if p.Closed {
 		p.buf.WriteString("#EXT-X-ENDLIST\n")

--- a/writer.go
+++ b/writer.go
@@ -333,8 +333,6 @@ func (p *MediaPlaylist) ResetCache() {
 
 // Generate output in M3U8 format. Marshal `winsize` elements from bottom of the `segments` queue.
 func (p *MediaPlaylist) Encode() *bytes.Buffer {
-	var seg *MediaSegment
-
 	if p.buf.Len() > 0 {
 		return &p.buf
 	}
@@ -467,6 +465,11 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 		}
 	}
 
+	var (
+		seg           *MediaSegment
+		durationCache = make(map[float64]string)
+	)
+
 	head := p.head
 	count := p.count
 	for i := uint(0); i < p.winsize && count > 0; count-- {
@@ -534,12 +537,17 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 			p.buf.WriteRune('\n')
 		}
 		p.buf.WriteString("#EXTINF:")
-		if p.durationAsInt {
-			// Old Android players has problems with non integer Duration.
-			p.buf.WriteString(strconv.FormatInt(int64(math.Ceil(seg.Duration)), 10))
+		if str, ok := durationCache[seg.Duration]; ok {
+			p.buf.WriteString(str)
 		} else {
-			// Wowza Mediaserver and some others prefer floats.
-			p.buf.WriteString(strconv.FormatFloat(seg.Duration, 'f', 3, 32))
+			if p.durationAsInt {
+				// Old Android players has problems with non integer Duration.
+				durationCache[seg.Duration] = strconv.FormatInt(int64(math.Ceil(seg.Duration)), 10)
+			} else {
+				// Wowza Mediaserver and some others prefer floats.
+				durationCache[seg.Duration] = strconv.FormatFloat(seg.Duration, 'f', 3, 32)
+			}
+			p.buf.WriteString(durationCache[seg.Duration])
 		}
 		p.buf.WriteRune(',')
 		p.buf.WriteString(seg.Title)

--- a/writer_test.go
+++ b/writer_test.go
@@ -22,7 +22,9 @@
 package m3u8
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -637,4 +639,41 @@ func ExampleMasterPlaylist_String() {
 	// chunklist1.m3u8
 	// #EXT-X-STREAM-INF:PROGRAM-ID=123,BANDWIDTH=1500000,RESOLUTION=576x480
 	// chunklist2.m3u8
+}
+
+/****************
+ *  Benchmarks  *
+ ****************/
+
+func BenchmarkEncodeMasterPlaylist(b *testing.B) {
+	f, err := os.Open("sample-playlists/master.m3u8")
+	if err != nil {
+		b.Fatal(err)
+	}
+	p := NewMasterPlaylist()
+	if err := p.DecodeFrom(bufio.NewReader(f), true); err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		p.ResetCache()
+		_ = p.Encode() // disregard output
+	}
+}
+
+func BenchmarkEncodeMediaPlaylist(b *testing.B) {
+	f, err := os.Open("sample-playlists/wowza-vod-chunklist.m3u8")
+	if err != nil {
+		b.Fatal(err)
+	}
+	p, err := NewMediaPlaylist(50000, 50000)
+	if err != nil {
+		b.Fatalf("Create media playlist failed: %s", err)
+	}
+	if err = p.DecodeFrom(bufio.NewReader(f), true); err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		p.ResetCache()
+		_ = p.Encode() // disregard output
+	}
 }


### PR DESCRIPTION
Alternative implementation of the improvements by @hori-ryota - all credits for actual changes is theirs. 
This PR cherry picks the biggest impact but lowest risk and maintains ABI compatibility.

This is only an example PR, and will need verification, approval and rebasing before merging.

This branch:

Before:
```
BenchmarkDecodeMasterPlaylist-4   100000             22425 ns/op           12195 B/op         77 allocs/op
BenchmarkDecodeMediaPlaylist-4        50          23947209 ns/op        12279896 B/op     160059 allocs/op
BenchmarkEncodeMasterPlaylist-4  1000000              1023 ns/op              40 B/op         11 allocs/op
BenchmarkEncodeMediaPlaylist-4       100          12931950 ns/op         1748991 B/op      81607 allocs/op
```

After:
```
BenchmarkDecodeMasterPlaylist-4   100000             22534 ns/op           12194 B/op         77 allocs/op
BenchmarkDecodeMediaPlaylist-4       100          16132527 ns/op        10999880 B/op     120059 allocs/op
BenchmarkEncodeMasterPlaylist-4  1000000              1016 ns/op              40 B/op         11 allocs/op
BenchmarkEncodeMediaPlaylist-4       300           4471880 ns/op           45421 B/op        405 allocs/op
```

Benchstat Summary:
```
name                    old time/op    new time/op    delta
DecodeMasterPlaylist-4    22.4µs ± 0%    22.5µs ± 0%   ~             (p=1.000 n=1+1)
DecodeMediaPlaylist-4     23.9ms ± 0%    16.1ms ± 0%   ~             (p=1.000 n=1+1)
EncodeMasterPlaylist-4    1.02µs ± 0%    1.02µs ± 0%   ~             (p=1.000 n=1+1)
EncodeMediaPlaylist-4     12.9ms ± 0%     4.5ms ± 0%   ~             (p=1.000 n=1+1)

name                    old alloc/op   new alloc/op   delta
DecodeMasterPlaylist-4    12.2kB ± 0%    12.2kB ± 0%   ~             (p=1.000 n=1+1)
DecodeMediaPlaylist-4     12.3MB ± 0%    11.0MB ± 0%   ~             (p=1.000 n=1+1)
EncodeMasterPlaylist-4     40.0B ± 0%     40.0B ± 0%   ~     (all samples are equal)
EncodeMediaPlaylist-4     1.75MB ± 0%    0.05MB ± 0%   ~             (p=1.000 n=1+1)

name                    old allocs/op  new allocs/op  delta
DecodeMasterPlaylist-4      77.0 ± 0%      77.0 ± 0%   ~     (all samples are equal)
DecodeMediaPlaylist-4       160k ± 0%      120k ± 0%   ~             (p=1.000 n=1+1)
EncodeMasterPlaylist-4      11.0 ± 0%      11.0 ± 0%   ~     (all samples are equal)
EncodeMediaPlaylist-4      81.6k ± 0%      0.4k ± 0%   ~             (p=1.000 n=1+1)
```

https://github.com/hori-ryota/m3u8 - feature/improve-perform-decodeplaylist

Before:
```
BenchmarkDecodeMasterPlaylist-4   100000             23203 ns/op           14955 B/op         77 allocs/op
BenchmarkDecodeMediaPlaylist-4        50          24187010 ns/op        12279952 B/op     160060 allocs/op
BenchmarkEncodeMediaPlaylist-4       100          12919057 ns/op         1748992 B/op      81607 allocs/op
```

After:
```
BenchmarkDecodeMasterPlaylist-4   200000             10104 ns/op           12240 B/op         35 allocs/op
BenchmarkDecodeMediaPlaylist-4       100          16193330 ns/op         9200522 B/op      80019 allocs/op
BenchmarkEncodeMediaPlaylist-4       500           3697907 ns/op           21128 B/op        163 allocs/op
```

Benchstat Summary:
```
name                    old time/op    new time/op    delta
DecodeMasterPlaylist-4    23.2µs ± 0%    10.1µs ± 0%   ~     (p=1.000 n=1+1)
DecodeMediaPlaylist-4     24.2ms ± 0%    16.2ms ± 0%   ~     (p=1.000 n=1+1)
EncodeMediaPlaylist-4     12.9ms ± 0%     3.7ms ± 0%   ~     (p=1.000 n=1+1)

name                    old alloc/op   new alloc/op   delta
DecodeMasterPlaylist-4    15.0kB ± 0%    12.2kB ± 0%   ~     (p=1.000 n=1+1)
DecodeMediaPlaylist-4     12.3MB ± 0%     9.2MB ± 0%   ~     (p=1.000 n=1+1)
EncodeMediaPlaylist-4     1.75MB ± 0%    0.02MB ± 0%   ~     (p=1.000 n=1+1)

name                    old allocs/op  new allocs/op  delta
DecodeMasterPlaylist-4      77.0 ± 0%      35.0 ± 0%   ~     (p=1.000 n=1+1)
DecodeMediaPlaylist-4       160k ± 0%       80k ± 0%   ~     (p=1.000 n=1+1)
EncodeMediaPlaylist-4      81.6k ± 0%      0.2k ± 0%   ~     (p=1.000 n=1+1)
```