### PR TITLE
Auto extend media playlist, expose winsize, set winsize 0 on VoD

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -152,7 +152,7 @@ func decode(buf *bytes.Buffer, strict bool) (Playlist, ListType, error) {
 	wv := new(WV)
 
 	master = NewMasterPlaylist()
-	media, err = NewMediaPlaylist(8, 1024) // Capacity auto extends
+	media, err = NewMediaPlaylist(8, 1024) // Winsize for VoD will become 0, capacity auto extends
 	if err != nil {
 		return nil, 0, fmt.Errorf("Create media playlist failed: %s", err)
 	}
@@ -194,6 +194,10 @@ func decode(buf *bytes.Buffer, strict bool) (Playlist, ListType, error) {
 	case MASTER:
 		return master, MASTER, nil
 	case MEDIA:
+		if media.Closed || media.MediaType == EVENT {
+			// VoD and Event's should show the entire playlist
+			media.SetWinSize(0)
+		}
 		return media, MEDIA, nil
 	default:
 		return nil, state.listType, errors.New("Can't detect playlist type")

--- a/reader_test.go
+++ b/reader_test.go
@@ -279,6 +279,9 @@ func TestDecodeMediaPlaylistWithAutodetection(t *testing.T) {
 	if !pp.Closed {
 		t.Error("This is a closed (VOD) playlist but Close field = false")
 	}
+	if pp.winsize != 0 {
+		t.Errorf("Media window size %v != 0", pp.winsize)
+	}
 	// TODO check other values…
 	// fmt.Println(pp.Encode().String())
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -237,7 +237,6 @@ func TestDecodeMediaPlaylistWithWidevine(t *testing.T) {
 }
 
 func TestDecodeMasterPlaylistWithAutodetection(t *testing.T) {
-	print("test")
 	f, err := os.Open("sample-playlists/master.m3u8")
 	if err != nil {
 		t.Fatal(err)
@@ -282,6 +281,28 @@ func TestDecodeMediaPlaylistWithAutodetection(t *testing.T) {
 	}
 	// TODO check other values…
 	// fmt.Println(pp.Encode().String())
+}
+
+// TestDecodeMediaPlaylistAutoDetectExtend tests a very large playlist auto
+// extends to the appropriate size.
+func TestDecodeMediaPlaylistAutoDetectExtend(t *testing.T) {
+	f, err := os.Open("sample-playlists/media-playlist-large.m3u8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, listType, err := DecodeFrom(bufio.NewReader(f), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pp := p.(*MediaPlaylist)
+	CheckType(t, pp)
+	if listType != MEDIA {
+		t.Error("Sample not recognized as media playlist.")
+	}
+	var exp uint = 40001
+	if pp.Count() != exp {
+		t.Errorf("Media segment count %v != %v", pp.Count(), exp)
+	}
 }
 
 /***************************

--- a/writer.go
+++ b/writer.go
@@ -254,13 +254,12 @@ func (p *MasterPlaylist) String() string {
 // Winsize defines how much items will displayed on playlist generation.
 // Capacity is total size of a playlist.
 func NewMediaPlaylist(winsize uint, capacity uint) (*MediaPlaylist, error) {
-	if capacity < winsize {
-		return nil, errors.New("capacity must be greater then winsize or equal")
-	}
 	p := new(MediaPlaylist)
 	p.ver = minver
-	p.winsize = winsize
 	p.capacity = capacity
+	if err := p.SetWinSize(winsize); err != nil {
+		return nil, err
+	}
 	p.Segments = make([]*MediaSegment, capacity)
 	return p, nil
 }
@@ -704,4 +703,18 @@ func (p *MediaPlaylist) Version() uint8 {
 // automatically by other Set methods.
 func (p *MediaPlaylist) SetVersion(ver uint8) {
 	p.ver = ver
+}
+
+// WinSize returns the playlist's window size.
+func (p *MediaPlaylist) WinSize() uint {
+	return p.winsize
+}
+
+// SetWinSize overwrites the playlist's window size.
+func (p *MediaPlaylist) SetWinSize(winsize uint) error {
+	if winsize > p.capacity {
+		return errors.New("capacity must be greater than winsize or equal")
+	}
+	p.winsize = winsize
+	return nil
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -489,6 +489,33 @@ func TestMediaSetVersion(t *testing.T) {
 	}
 }
 
+func TestMediaWinSize(t *testing.T) {
+	m, _ := NewMediaPlaylist(3, 3)
+	if m.WinSize() != m.winsize {
+		t.Errorf("Expected winsize: %v, got: %v", m.winsize, m.WinSize())
+	}
+}
+
+func TestMediaSetWinSize(t *testing.T) {
+	m, _ := NewMediaPlaylist(3, 5)
+	err := m.SetWinSize(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.winsize != 5 {
+		t.Errorf("Expected winsize: %v, got: %v", 5, m.winsize)
+	}
+	// Check winsize cannot exceed capacity
+	err = m.SetWinSize(99999)
+	if err == nil {
+		t.Error("Expected error, received: ", err)
+	}
+	// Ensure winsize didn't change
+	if m.winsize != 5 {
+		t.Errorf("Expected winsize: %v, got: %v", 5, m.winsize)
+	}
+}
+
 // Create new master playlist without params
 // Add media playlist
 func TestNewMasterPlaylist(t *testing.T) {


### PR DESCRIPTION
There are three related commits here all addressing issues.

## Expose setter and getter for media playlist winsize

0f55de01b9a5bf2be3f843e9279e54de59281a7a fixes #53 and finishes #22, this exposes two new methods for a media playlist, `SetWinSet()` and `WinSize()` which sets and gets the winsize respectively.

## Auto extend media playlist when decoding without a media playlist

78a4147c7f5d2cd5f91b29cb712634394d444c35 fixes #5, when decoding a playlist using the `Decode()` or `DecodeFrom()` functions (not the equivalent methods on a Master/Media Playlist), the decode function would create a new media playlist with a winsize of 8 and capacity of 1024. If the playlist was >1024 segments, the remaining segments would be dropped.

This auto extends the playlist in this case (not when using the media playlist decode methods) but doubling its size each time. In no other cases are playlists extendable.

## Set winsize 0 on VoD/EVENT playlist when decoding without media playlist

25316ccbea221ea9d74030b9092d2f114b00ce8c addresses #53, related to the previously mention commit 78a4147c7f5d2cd5f91b29cb712634394d444c35, this also changes the winsize from 8 to 0 for VoD and EVENT playlists to display in full.