### PR TITLE
Use path.Join in example

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -14,8 +14,8 @@ func main() {
 	if GOPATH == "" {
 		panic("$GOPATH is empty")
 	}
-	this := "github.com/grafov/m3u8"
-	f, err := os.Open(path.Join(GOPATH, "src", this, "/sample-playlists/media-playlist-with-byterange.m3u8"))
+	m3u8File := "github.com/grafov/m3u8/sample-playlists/media-playlist-with-byterange.m3u8"
+	f, err := os.Open(path.Join(GOPATH, "src", m3u8File))
 	if err != nil {
 		panic(err)
 	}

--- a/example/example.go
+++ b/example/example.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/grafov/m3u8"
 )
@@ -14,7 +15,7 @@ func main() {
 		panic("$GOPATH is empty")
 	}
 	this := "github.com/grafov/m3u8"
-	f, err := os.Open(GOPATH + "/src/" + this + "/sample-playlists/media-playlist-with-byterange.m3u8")
+	f, err := os.Open(path.Join(GOPATH, "src", this, "/sample-playlists/media-playlist-with-byterange.m3u8"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Use `path.Join` to create a file path.
we can avoid these common errors.

- path/tofile
- path/to//file


Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grafov/m3u8/73)
<!-- Reviewable:end -->
