### PR TITLE
Remove unnecessary args in goveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
  - go build -a -v ./...
  - diff <(gofmt -d .) <("")
  - go test -v -covermode=count -coverprofile=coverage.out
- - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+ - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci


### PR DESCRIPTION
I met this error in travis-ci.
```bash
$ $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
flag needs an argument: -repotoken
...
The command "$GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN" exited with 2.
```

## Resolution

`$COVERALLS_TOKEN` is not necessary.
c.f. [Docs](https://github.com/mattn/goveralls#travis-ci)
> For a public github repository, it is not necessary to define your repository key (COVERALLS_TOKEN).


In other ways, add `=` like this.
maybe, it works.
- before:	`-repotoken $COVERALLS_TOKEN`
- after:	`-repotoken=$COVERALLS_TOKEN`

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grafov/m3u8/75)
<!-- Reviewable:end -->