### PR TITLE
Time Parsing fix for #EXT-X-PROGRAM-DATE-TIME

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -501,8 +501,21 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 	case !state.tagProgramDateTime && strings.HasPrefix(line, "#EXT-X-PROGRAM-DATE-TIME:"):
 		state.tagProgramDateTime = true
 		state.listType = MEDIA
-		if state.programDateTime, err = time.Parse(DATETIME, line[25:]); strict && err != nil {
-			return err
+		switch {
+		case rgx_rfc3339Nano.MatchString(line[25:]):
+			if state.programDateTime, err = time.Parse(RFC3339Nano, line[25:]); strict && err != nil {
+				return err
+			}
+		case rgx_rfc3339Nano_1.MatchString(line[25:]):
+			if state.programDateTime, err = time.Parse(RFC3339Nano_1, line[25:]); strict && err != nil {
+				return err
+			}
+		case rgx_rfc3339Nano_2.MatchString(line[25:]):
+			if state.programDateTime, err = time.Parse(RFC3339Nano_2, line[25:]); strict && err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("parsing time %s do not match ISO8601/RFC3339 patterns: %s .", line[25:], time.RFC3339)
 		}
 	case !state.tagRange && strings.HasPrefix(line, "#EXT-X-BYTERANGE:"):
 		state.tagRange = true

--- a/reader.go
+++ b/reader.go
@@ -511,7 +511,6 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 		if state.programDateTime, err = TimeParse(line[25:]); strict && err != nil {
 			return err
 		}
-
 	case !state.tagRange && strings.HasPrefix(line, "#EXT-X-BYTERANGE:"):
 		state.tagRange = true
 		state.listType = MEDIA
@@ -647,12 +646,12 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 	return err
 }
 
-// Strict Time Wrapper implements RFC3339 with Nanoseconds accuracy
+// StrictTimeParse implements RFC3339 with Nanoseconds accuracy.
 func StrictTimeParse(value string) (time.Time, error) {
 	return time.Parse(DATETIME, value)
 }
 
-// Custom Time Parser implements ISO/IEC 8601:2004
+// FullTimeParse implements ISO/IEC 8601:2004.
 func FullTimeParse(value string) (time.Time, error) {
 	layouts := []string{
 		"2006-01-02T15:04:05.999999999Z0700",

--- a/reader.go
+++ b/reader.go
@@ -507,7 +507,6 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 	case !state.tagProgramDateTime && strings.HasPrefix(line, "#EXT-X-PROGRAM-DATE-TIME:"):
 		state.tagProgramDateTime = true
 		state.listType = MEDIA
-
 		if state.programDateTime, err = TimeParse(line[25:]); strict && err != nil {
 			return err
 		}

--- a/reader_test.go
+++ b/reader_test.go
@@ -297,8 +297,9 @@ func TestDecodeMediaPlaylistAutoDetectExtend(t *testing.T) {
 }
 
 // Tests for Time Parsing of EXT-X-PROGRAM-DATE-TIME
-// We testing RFC3339 where we ca nget time in UTC, UTC with Nanoseconds
+// We testing ISO/IEC 8601:2004 where we can get time in UTC, UTC with Nanoseconds
 // timeZone in formats '±00:00', '±0000', '±00'
+// m3u8.FullTimeParse()
 func TestTimeLayoutsDecode(t *testing.T) {
 	time_in_utc := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05Z"
 	time_in_utc_nano := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05.123456789Z"
@@ -319,56 +320,140 @@ func TestTimeLayoutsDecode(t *testing.T) {
 	var err error
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_in_utc, err)
 	}
 
 	state = new(decodingState)
 	wv = new(WV)
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc_nano, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_in_utc_nano, err)
 	}
 
 	state = new(decodingState)
 	wv = new(WV)
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_and_colon, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_and_colon, err)
 	}
 
 	state = new(decodingState)
 	wv = new(WV)
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_no_colon, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_no_colon, err)
 	}
 
 	state = new(decodingState)
 	wv = new(WV)
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_2digits, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_2digits, err)
 	}
 
 	state = new(decodingState)
 	wv = new(WV)
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_and_colon, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_and_colon, err)
 	}
 
 	state = new(decodingState)
 	wv = new(WV)
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_no_colon, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_no_colon, err)
 	}
 
 	state = new(decodingState)
 	wv = new(WV)
 	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_2digits, true)
 	if err != nil {
-		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_2digits, err)
+	}
+}
+
+// Tests for Time Parsing of EXT-X-PROGRAM-DATE-TIME
+// We testing Strict format of RFC3339 where we can get time in UTC, UTC with Nanoseconds
+// timeZone in formats '±00:00', '±0000', '±00'
+// m3u8.StrictTimeParse()
+func TestStrictTimeLayoutsDecode(t *testing.T) {
+
+	// Should Pass
+	time_in_utc := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05Z"
+	time_in_utc_nano := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05.123456789Z"
+	time_with_positive_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01:00"
+	time_with_negative_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01:00"
+
+	// Should Fail
+	time_with_positive_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+0100"
+	time_with_positive_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01"
+	time_with_negative_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-0100"
+	time_with_negative_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01"
+
+	// Set TimeParse function to StrictTimeParse (RFC3339 Only)
+	TimeParse = StrictTimeParse
+
+	p, e := NewMediaPlaylist(1, 2)
+	if e != nil {
+		t.Fatalf("Create media playlist failed: %s", e)
+	}
+	state := new(decodingState)
+	wv := new(WV)
+
+	var err error
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for %s: %s", time_in_utc, err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc_nano, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for %s: %s", time_in_utc_nano, err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_and_colon, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_and_colon, err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_no_colon, true)
+	if err != nil {
+		t.Logf("Time Parser Error for %s: %s", time_with_positive_zone_no_colon, err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_2digits, true)
+	if err != nil {
+		t.Logf("Time Parser Error for %s: %s", time_with_positive_zone_2digits, err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_and_colon, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_and_colon, err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_no_colon, true)
+	if err != nil {
+		t.Logf("Time Parser Error for %s: %s", time_with_negative_zone_no_colon, err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_2digits, true)
+	if err != nil {
+		t.Logf("Time Parser Error for %s: %s", time_with_negative_zone_2digits, err)
 	}
 }
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -296,6 +296,82 @@ func TestDecodeMediaPlaylistAutoDetectExtend(t *testing.T) {
 	}
 }
 
+// Tests for Time Parsing of EXT-X-PROGRAM-DATE-TIME
+// We testing RFC3339 where we ca nget time in UTC, UTC with Nanoseconds
+// timeZone in formats '±00:00', '±0000', '±00'
+func TestTimeLayoutsDecode(t *testing.T) {
+	time_in_utc := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05Z"
+	time_in_utc_nano := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05.123456789Z"
+	time_with_positive_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01:00"
+	time_with_positive_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+0100"
+	time_with_positive_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01"
+	time_with_negative_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01:00"
+	time_with_negative_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-0100"
+	time_with_negative_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01"
+
+	p, e := NewMediaPlaylist(1, 2)
+	if e != nil {
+		t.Fatalf("Create media playlist failed: %s", e)
+	}
+	state := new(decodingState)
+	wv := new(WV)
+
+	var err error
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc_nano, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_and_colon, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_no_colon, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_2digits, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_and_colon, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_no_colon, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+
+	state = new(decodingState)
+	wv = new(WV)
+	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_2digits, true)
+	if err != nil {
+		t.Errorf("Time Parser Error for EXT-X-PROGRAM-DATE-TIME: %s", err)
+	}
+}
+
 /***************************
  *  Code parsing examples  *
  ***************************/

--- a/reader_test.go
+++ b/reader_test.go
@@ -296,164 +296,55 @@ func TestDecodeMediaPlaylistAutoDetectExtend(t *testing.T) {
 	}
 }
 
-// Tests for Time Parsing of EXT-X-PROGRAM-DATE-TIME
+// Test for FullTimeParse of EXT-X-PROGRAM-DATE-TIME
 // We testing ISO/IEC 8601:2004 where we can get time in UTC, UTC with Nanoseconds
 // timeZone in formats '±00:00', '±0000', '±00'
 // m3u8.FullTimeParse()
-func TestTimeLayoutsDecode(t *testing.T) {
-	time_in_utc := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05Z"
-	time_in_utc_nano := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05.123456789Z"
-	time_with_positive_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01:00"
-	time_with_positive_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+0100"
-	time_with_positive_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01"
-	time_with_negative_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01:00"
-	time_with_negative_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-0100"
-	time_with_negative_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01"
-
-	p, e := NewMediaPlaylist(1, 2)
-	if e != nil {
-		t.Fatalf("Create media playlist failed: %s", e)
+func TestFullTimeParse(t *testing.T) {
+	var timestamps = []struct {
+		name  string
+		value string
+	}{
+		{"time_in_utc", "2006-01-02T15:04:05Z"},
+		{"time_in_utc_nano", "2006-01-02T15:04:05.123456789Z"},
+		{"time_with_positive_zone_and_colon", "2006-01-02T15:04:05+01:00"},
+		{"time_with_positive_zone_no_colon", "2006-01-02T15:04:05+0100"},
+		{"time_with_positive_zone_2digits", "2006-01-02T15:04:05+01"},
+		{"time_with_negative_zone_and_colon", "2006-01-02T15:04:05-01:00"},
+		{"time_with_negative_zone_no_colon", "2006-01-02T15:04:05-0100"},
+		{"time_with_negative_zone_2digits", "2006-01-02T15:04:05-01"},
 	}
-	state := new(decodingState)
-	wv := new(WV)
 
 	var err error
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_in_utc, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc_nano, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_in_utc_nano, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_and_colon, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_and_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_no_colon, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_no_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_2digits, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_2digits, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_and_colon, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_and_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_no_colon, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_no_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_2digits, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_2digits, err)
+	for _, tstamp := range timestamps {
+		_, err = FullTimeParse(tstamp.value)
+		if err != nil {
+			t.Errorf("FullTimeParse Error at %s [%s]: %s", tstamp.name, tstamp.value, err)
+		}
 	}
 }
 
-// Tests for Time Parsing of EXT-X-PROGRAM-DATE-TIME
+// Test for StrictTimeParse of EXT-X-PROGRAM-DATE-TIME
 // We testing Strict format of RFC3339 where we can get time in UTC, UTC with Nanoseconds
 // timeZone in formats '±00:00', '±0000', '±00'
 // m3u8.StrictTimeParse()
-func TestStrictTimeLayoutsDecode(t *testing.T) {
-
-	// Should Pass
-	time_in_utc := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05Z"
-	time_in_utc_nano := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05.123456789Z"
-	time_with_positive_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01:00"
-	time_with_negative_zone_and_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01:00"
-
-	// Should Fail
-	time_with_positive_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+0100"
-	time_with_positive_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05+01"
-	time_with_negative_zone_no_colon := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-0100"
-	time_with_negative_zone_2digits := "#EXT-X-PROGRAM-DATE-TIME:2006-01-02T15:04:05-01"
-
-	// Set TimeParse function to StrictTimeParse (RFC3339 Only)
-	TimeParse = StrictTimeParse
-
-	p, e := NewMediaPlaylist(1, 2)
-	if e != nil {
-		t.Fatalf("Create media playlist failed: %s", e)
+func TestStrictTimeParse(t *testing.T) {
+	var timestamps = []struct {
+		name  string
+		value string
+	}{
+		{"time_in_utc", "2006-01-02T15:04:05Z"},
+		{"time_in_utc_nano", "2006-01-02T15:04:05.123456789Z"},
+		{"time_with_positive_zone_and_colon", "2006-01-02T15:04:05+01:00"},
+		{"time_with_negative_zone_and_colon", "2006-01-02T15:04:05-01:00"},
 	}
-	state := new(decodingState)
-	wv := new(WV)
 
 	var err error
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_in_utc, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_in_utc_nano, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_in_utc_nano, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_and_colon, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_positive_zone_and_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_no_colon, true)
-	if err != nil {
-		t.Logf("Time Parser Error for %s: %s", time_with_positive_zone_no_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_positive_zone_2digits, true)
-	if err != nil {
-		t.Logf("Time Parser Error for %s: %s", time_with_positive_zone_2digits, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_and_colon, true)
-	if err != nil {
-		t.Errorf("Time Parser Error for %s: %s", time_with_negative_zone_and_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_no_colon, true)
-	if err != nil {
-		t.Logf("Time Parser Error for %s: %s", time_with_negative_zone_no_colon, err)
-	}
-
-	state = new(decodingState)
-	wv = new(WV)
-	err = decodeLineOfMediaPlaylist(p, wv, state, time_with_negative_zone_2digits, true)
-	if err != nil {
-		t.Logf("Time Parser Error for %s: %s", time_with_negative_zone_2digits, err)
+	for _, tstamp := range timestamps {
+		_, err = StrictTimeParse(tstamp.value)
+		if err != nil {
+			t.Errorf("StrictTimeParse Error at %s [%s]: %s", tstamp.name, tstamp.value, err)
+		}
 	}
 }
 

--- a/structure.go
+++ b/structure.go
@@ -14,6 +14,7 @@ package m3u8
 import (
 	"bytes"
 	"io"
+	"regexp"
 	"time"
 )
 
@@ -31,8 +32,25 @@ const (
 		   o  The EXT-X-MEDIA tag.
 		   o  The AUDIO and VIDEO attributes of the EXT-X-STREAM-INF tag.
 	*/
-	minver   = uint8(3)
+	minver = uint8(3)
+
 	DATETIME = time.RFC3339Nano // Format for EXT-X-PROGRAM-DATE-TIME defined in section 3.4.5
+
+	// time Layouts which is used during Manifest Ingestion for EXT-X-PROGRAM-DATE-TIME
+	// According to RFC3339 and ISO8601
+	// TimeZone can be set as '±00:00', '±0000', '±00' and all those variants is legit Datetime according to ISO8601/RFC3339
+	// So we want to have more precise Parser's layouts for incoming manifest to avoid time.Parse() error
+	// See this: https://en.wikipedia.org/wiki/ISO_8601
+	RFC3339Nano   = "2006-01-02T15:04:05.999999999Z07:00"
+	RFC3339Nano_1 = "2006-01-02T15:04:05.999999999Z0700"
+	RFC3339Nano_2 = "2006-01-02T15:04:05.999999999Z07"
+)
+
+var (
+	// Compile Regex to match incoming timeformat to use correct time layout for time.Parse()
+	rgx_rfc3339Nano   = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}:\d{2})?$`)
+	rgx_rfc3339Nano_1 = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}\d{2})?$`)
+	rgx_rfc3339Nano_2 = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2})?$`)
 )
 
 type ListType uint

--- a/structure.go
+++ b/structure.go
@@ -34,7 +34,6 @@ const (
 	minver = uint8(3)
 
 	DATETIME = time.RFC3339Nano // Format for EXT-X-PROGRAM-DATE-TIME defined in section 3.4.5
-
 )
 
 type ListType uint

--- a/structure.go
+++ b/structure.go
@@ -41,16 +41,16 @@ const (
 	// TimeZone can be set as '±00:00', '±0000', '±00' and all those variants is legit Datetime according to ISO8601/RFC3339
 	// So we want to have more precise Parser's layouts for incoming manifest to avoid time.Parse() error
 	// See this: https://en.wikipedia.org/wiki/ISO_8601
-	RFC3339Nano   = "2006-01-02T15:04:05.999999999Z07:00"
-	RFC3339Nano_1 = "2006-01-02T15:04:05.999999999Z0700"
-	RFC3339Nano_2 = "2006-01-02T15:04:05.999999999Z07"
+	ISO8601      = "2006-01-02T15:04:05.999999999Z0700"
+	ISO8601Colon = "2006-01-02T15:04:05.999999999Z07:00"
+	ISO8601Short = "2006-01-02T15:04:05.999999999Z07"
 )
 
 var (
 	// Compile Regex to match incoming timeformat to use correct time layout for time.Parse()
-	rgx_rfc3339Nano   = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}:\d{2})?$`)
-	rgx_rfc3339Nano_1 = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}\d{2})?$`)
-	rgx_rfc3339Nano_2 = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2})?$`)
+	rgx_ISO8601      = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}\d{2})?$`)
+	rgx_ISO8601Colon = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}:\d{2})?$`)
+	rgx_ISO8601Short = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2})?$`)
 )
 
 type ListType uint

--- a/structure.go
+++ b/structure.go
@@ -31,8 +31,7 @@ const (
 		   o  The EXT-X-MEDIA tag.
 		   o  The AUDIO and VIDEO attributes of the EXT-X-STREAM-INF tag.
 	*/
-	minver = uint8(3)
-
+	minver   = uint8(3)
 	DATETIME = time.RFC3339Nano // Format for EXT-X-PROGRAM-DATE-TIME defined in section 3.4.5
 )
 

--- a/structure.go
+++ b/structure.go
@@ -14,7 +14,6 @@ package m3u8
 import (
 	"bytes"
 	"io"
-	"regexp"
 	"time"
 )
 
@@ -36,21 +35,6 @@ const (
 
 	DATETIME = time.RFC3339Nano // Format for EXT-X-PROGRAM-DATE-TIME defined in section 3.4.5
 
-	// time Layouts which is used during Manifest Ingestion for EXT-X-PROGRAM-DATE-TIME
-	// According to RFC3339 and ISO8601
-	// TimeZone can be set as '±00:00', '±0000', '±00' and all those variants is legit Datetime according to ISO8601/RFC3339
-	// So we want to have more precise Parser's layouts for incoming manifest to avoid time.Parse() error
-	// See this: https://en.wikipedia.org/wiki/ISO_8601
-	ISO8601      = "2006-01-02T15:04:05.999999999Z0700"
-	ISO8601Colon = "2006-01-02T15:04:05.999999999Z07:00"
-	ISO8601Short = "2006-01-02T15:04:05.999999999Z07"
-)
-
-var (
-	// Compile Regex to match incoming timeformat to use correct time layout for time.Parse()
-	rgx_ISO8601      = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}\d{2})?$`)
-	rgx_ISO8601Colon = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2}:\d{2})?$`)
-	rgx_ISO8601Short = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:.\d{1,9})?(Z|\+|\-)(\d{2})?$`)
 )
 
 type ListType uint


### PR DESCRIPTION
While HLS Draft in section 3.4.5 require that time should comply with RFC3339, during my work i noticed that many Encoders use ISO8601 where Timezone representation is less strict than RFC3339.
ISO8601 allow to expose TZ in several ways:
```
DateTime/Zone
<time>Z
<time>±hh:mm (by RFC3339)
<time>±hhmm
<time>±hh
```

Example of manifest where we getting Parser error:
```
#EXTM3U
#EXT-X-TARGETDURATION:8
#EXT-X-PROGRAM-DATE-TIME:2017-01-30T17:26:04+0100
#EXT-X-MEDIA-SEQUENCE:855733
#EXTINF:8,
1478947334-fast-1920-1080-2750000-855733.ts
#EXTINF:8,
1478947334-fast-1920-1080-2750000-855734.ts
#EXTINF:8,
1478947334-fast-1920-1080-2750000-855735.ts
```
Error itself:
`parsing time "2017-01-30T17:26:04+0100" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "+0100" as "Z07:00"`

But while RFC3339 newer then ISO8601, lot of software still use it, so my proposal is to create Format validation for incoming tag #EXT-X-PROGRAM-DATE-TIME in `reader.go` and using `switch{case}` test incoming string against precompiled regexp rules, and route string to time.Parse() with proper layout(format).

I implemented only RFC3339 with Nano seconds, this should be enough and in case we need add other formats this will be easy to add to `switch{case}` chain.
