### PR TITLE
Make comma optional in #EXTINF when strict mode is false

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -358,7 +358,10 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 		state.listType = MEDIA
 		sepIndex := strings.Index(line, ",")
 		if sepIndex == -1 {
-			break
+			if strict {
+				return fmt.Errorf("could not parse: %q", line)
+			}
+			sepIndex = len(line)
 		}
 		duration := line[8:sepIndex]
 		if len(duration) > 0 {


### PR DESCRIPTION
*This is a potential breaking change*

Previously we would skip a segment which doesn't have a comma in the

For example, the following playlist would have a single nil segment.

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:10
c_1267327549363093.ts
```

The new behaviour will cause an error to be returned when parsing if
we're operating in strict mode. If we're not operating in strict mode
the duration will be parsed succesfully as 10.000, with an empty title.

Fixes #84.