### PR TITLE
Add InsertSegment to account for when segments arrive out-of-order

### DIFF
--- a/structure.go
+++ b/structure.go
@@ -14,6 +14,7 @@ package m3u8
 import (
 	"bytes"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -121,6 +122,7 @@ type MediaPlaylist struct {
 	Key            *Key // EXT-X-KEY is optional encryption key displayed before any segments (default key for the playlist)
 	Map            *Map // EXT-X-MAP is optional tag specifies how to obtain the Media Initialization Section (default map for the playlist)
 	WV             *WV  // Widevine related tags outside of M3U8 specs
+	lock           *sync.Mutex
 }
 
 /*

--- a/writer.go
+++ b/writer.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -261,6 +262,7 @@ func NewMediaPlaylist(winsize uint, capacity uint) (*MediaPlaylist, error) {
 		return nil, err
 	}
 	p.Segments = make([]*MediaSegment, capacity)
+	p.lock = &sync.Mutex{}
 	return p, nil
 }
 
@@ -335,6 +337,8 @@ func (p *MediaPlaylist) InsertSegment(seqNo uint64, seg *MediaSegment) error {
 		return ErrSegmentAlreadyExists
 	}
 
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	err = p.AppendSegment(seg)
 
 	//Sort if the inserted segment is out of order

--- a/writer_test.go
+++ b/writer_test.go
@@ -97,32 +97,64 @@ func TestAppendSegmentToMediaPlaylist(t *testing.T) {
 }
 
 func TestInsertSegmentToMediaPlaylist(t *testing.T) {
-	p, _ := NewMediaPlaylist(4, 4)
-	e := p.InsertSegment(&MediaSegment{SeqId: 0})
+	p, _ := NewMediaPlaylist(3, 10)
+	e := p.InsertSegment(1, &MediaSegment{SeqId: 1})
 	if e != nil {
 		t.Errorf("Add 1st segment to a media playlist failed: %s", e)
 	}
 
-	e = p.InsertSegment(&MediaSegment{SeqId: 2})
+	e = p.InsertSegment(3, &MediaSegment{SeqId: 3})
 	if e != nil {
 		t.Errorf("Add 2nd segment to a media playlist failed: %s", e)
 	}
 
-	e = p.InsertSegment(&MediaSegment{SeqId: 1})
+	e = p.InsertSegment(2, &MediaSegment{SeqId: 2})
 	if e != nil {
 		t.Errorf("Add 3rd segment to a media playlist failed: %s", e)
 	}
 
 	for i := uint64(0); i < 3; i++ {
-		if p.Segments[i].SeqId != i {
-			t.Errorf("Expecting SeqNo to be %d, got %d", i, p.Segments[i].SeqId)
+		if p.Segments[i].SeqId != i+1 {
+			t.Errorf("Expecting SeqNo to be %d, got %d", i+1, p.Segments[i].SeqId)
 		}
 	}
 
-	e = p.InsertSegment(&MediaSegment{SeqId: 0})
+	e = p.InsertSegment(1, &MediaSegment{SeqId: 1})
 	if e != ErrSegmentAlreadyExists {
 		t.Errorf("Add 4th expected segment already exists error, got %s", e)
 	}
+
+	e = p.InsertSegment(0, &MediaSegment{SeqId: 0})
+	if e != nil {
+		t.Errorf("Add 4th segment to a media playlist failed: %s", e)
+	}
+
+	if p.head != 1 {
+		t.Errorf("Head should be 1, but got %v", p.head)
+	}
+
+	if p.count != 3 {
+		t.Errorf("Count should be 3, but got %v", p.count)
+	}
+
+	if p.tail != 4 {
+		t.Errorf("Tail should be 4, but got %v", p.tail)
+	}
+
+	e = p.InsertSegment(4, &MediaSegment{SeqId: 4})
+	if e != nil {
+		t.Errorf("Add 5th segment to a media playlist failed: %s", e)
+	}
+
+	e = p.InsertSegment(3, &MediaSegment{SeqId: 3})
+	if e != ErrSegmentAlreadyExists {
+		t.Errorf("Add 6th expected segment already exists error, got %s", e)
+	}
+
+	if p.SeqNo != 2 {
+		t.Errorf("SeqNo should be 2, but got %v", p.SeqNo)
+	}
+
 }
 
 // Create new media playlist

--- a/writer_test.go
+++ b/writer_test.go
@@ -96,6 +96,35 @@ func TestAppendSegmentToMediaPlaylist(t *testing.T) {
 	}
 }
 
+func TestInsertSegmentToMediaPlaylist(t *testing.T) {
+	p, _ := NewMediaPlaylist(4, 4)
+	e := p.InsertSegment(&MediaSegment{SeqId: 0})
+	if e != nil {
+		t.Errorf("Add 1st segment to a media playlist failed: %s", e)
+	}
+
+	e = p.InsertSegment(&MediaSegment{SeqId: 2})
+	if e != nil {
+		t.Errorf("Add 2nd segment to a media playlist failed: %s", e)
+	}
+
+	e = p.InsertSegment(&MediaSegment{SeqId: 1})
+	if e != nil {
+		t.Errorf("Add 3rd segment to a media playlist failed: %s", e)
+	}
+
+	for i := uint64(0); i < 3; i++ {
+		if p.Segments[i].SeqId != i {
+			t.Errorf("Expecting SeqNo to be %d, got %d", i, p.Segments[i].SeqId)
+		}
+	}
+
+	e = p.InsertSegment(&MediaSegment{SeqId: 0})
+	if e != ErrSegmentAlreadyExists {
+		t.Errorf("Add 4th expected segment already exists error, got %s", e)
+	}
+}
+
 // Create new media playlist
 // Add three segments to media playlist
 // Set discontinuity tag for the 2nd segment.


### PR DESCRIPTION
Hi @grafov, I added an InsertSegment method to account for when segments arrive out-of-order during a live-streaming scenario.  It was useful for me in a p2p context.

Just want to merge back in case this is useful for you as well :)