### PR TITLE
added m3u8-reader project to Library usage section in REAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Also the library used in opensource software so you may look at these apps for u
 * [HLS downloader](https://github.com/kz26/gohls)
 * [Another HLS downloader](https://github.com/Makombo/hlsdownloader)
 * [HLS utils](https://github.com/archsh/hls-utils)
+* [M3U8 reader](https://github.com/jeongmin/m3u8-reader)
 
 M3U8 parsing/generation in other languages
 ------------------------------------------


### PR DESCRIPTION
I've made an webpage that is showing m3u8 format of URL which user inserted. It is built on your parser. If you don't mind, could you add my project to Library Usage section in your README?

Here is the my project link and screenshot.

https://github.com/jeongmin/m3u8-reader

![Screenshot of HLS READER](https://github.com/jeongmin/hls-reader/blob/master/screenshot.png?raw=true)