### PR TITLE
Extend method for MediaPlaylist

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -323,6 +323,19 @@ func (p *MediaPlaylist) Slide(uri string, duration float64, title string) {
 	p.Append(uri, duration, title)
 }
 
+// Extend increases the capacity of the media playlist by the value specified.
+// The tail of the playlist is moved to account for the new capacity.
+func (p *MediaPlaylist) Extend(additionalElements uint) {
+	if additionalElements == 0 {
+		return
+	}
+	newSegments := make([]*MediaSegment, len(p.Segments)+int(additionalElements))
+	copy(newSegments, p.Segments)
+	p.Segments = newSegments
+	p.capacity = uint(len(p.Segments))
+	p.tail = p.count
+}
+
 // Reset playlist cache. Next called Encode() will regenerate playlist from the chunk slice.
 func (p *MediaPlaylist) ResetCache() {
 	p.buf.Reset()

--- a/writer_test.go
+++ b/writer_test.go
@@ -774,6 +774,38 @@ func TestMasterSetVersion(t *testing.T) {
 	}
 }
 
+func TestExtend(t *testing.T) {
+	capacity := uint(5)
+	p, e := NewMediaPlaylist(0, capacity)
+	if e != nil {
+		t.Fatalf("Create media playlist failed: %s", e)
+	}
+	for i := 0; i < 5; i++ {
+		e = p.Append(fmt.Sprintf("test%d.ts", i), 5.0, "")
+		if e != nil {
+			t.Errorf("Add segment #%d to a media playlist failed: %s", i, e)
+		}
+	}
+	e = p.Append("test5.ts", 5.0, "")
+	if e == nil {
+		t.Errorf("Adding segment to media playlist should fail: over capacity")
+	}
+
+	additional := uint(2)
+	p.Extend(additional)
+	for i := uint(5); i < capacity+additional; i++ {
+		e = p.Append(fmt.Sprintf("test%d.ts", i), 5.0, "")
+		if e != nil {
+			t.Errorf("Add segment #%d to a media playlist failed: %s", i, e)
+		}
+	}
+
+	e = p.Append("test7.ts", 5.0, "")
+	if e == nil {
+		t.Errorf("Adding segment to media playlist should fail: over capacity")
+	}
+}
+
 /******************************
  *  Code generation examples  *
  ******************************/


### PR DESCRIPTION
To increase the capacity of a MediaPlaylist.
This is useful when dynamically generating playlists that may need to Append beyond the original capacity.