### PR TITLE
Added a couple newer attributes

### DIFF
--- a/structure.go
+++ b/structure.go
@@ -158,17 +158,18 @@ type Variant struct {
 // This structure represents additional parameters for a variant
 // used in EXT-X-STREAM-INF and EXT-X-I-FRAME-STREAM-INF
 type VariantParams struct {
-	ProgramId    uint32
-	Bandwidth    uint32
-	Codecs       string
-	Resolution   string
-	Audio        string // EXT-X-STREAM-INF only
-	Video        string
-	Subtitles    string         // EXT-X-STREAM-INF only
-	Captions     string         // EXT-X-STREAM-INF only
-	Name         string         // EXT-X-STREAM-INF only (non standard Wowza/JWPlayer extension to name the variant/quality in UA)
-	Iframe       bool           // EXT-X-I-FRAME-STREAM-INF
-	Alternatives []*Alternative // EXT-X-MEDIA
+	ProgramId        uint32
+	Bandwidth        uint32
+	AverageBandwidth uint32
+	Codecs           string
+	Resolution       string
+	Audio            string // EXT-X-STREAM-INF only
+	Video            string
+	Subtitles        string         // EXT-X-STREAM-INF only
+	Captions         string         // EXT-X-STREAM-INF only
+	Name             string         // EXT-X-STREAM-INF only (non standard Wowza/JWPlayer extension to name the variant/quality in UA)
+	Iframe           bool           // EXT-X-I-FRAME-STREAM-INF
+	Alternatives     []*Alternative // EXT-X-MEDIA
 }
 
 // This structure represents EXT-X-MEDIA tag in variants.

--- a/structure.go
+++ b/structure.go
@@ -102,25 +102,26 @@ const (
    https://priv.example.com/fileSequence2682.ts
 */
 type MediaPlaylist struct {
-	TargetDuration float64
-	SeqNo          uint64 // EXT-X-MEDIA-SEQUENCE
-	Segments       []*MediaSegment
-	Args           string // optional arguments placed after URIs (URI?Args)
-	Iframe         bool   // EXT-X-I-FRAMES-ONLY
-	Closed         bool   // is this VOD (closed) or Live (sliding) playlist?
-	MediaType      MediaType
-	durationAsInt  bool // output durations as integers of floats?
-	keyformat      int
-	winsize        uint // max number of segments displayed in an encoded playlist; need set to zero for VOD playlists
-	capacity       uint // total capacity of slice used for the playlist
-	head           uint // head of FIFO, we add segments to head
-	tail           uint // tail of FIFO, we remove segments from tail
-	count          uint // number of segments added to the playlist
-	buf            bytes.Buffer
-	ver            uint8
-	Key            *Key // EXT-X-KEY is optional encryption key displayed before any segments (default key for the playlist)
-	Map            *Map // EXT-X-MAP is optional tag specifies how to obtain the Media Initialization Section (default map for the playlist)
-	WV             *WV  // Widevine related tags outside of M3U8 specs
+	TargetDuration      float64
+	SeqNo               uint64 // EXT-X-MEDIA-SEQUENCE
+	Segments            []*MediaSegment
+	Args                string // optional arguments placed after URIs (URI?Args)
+	Iframe              bool   // EXT-X-I-FRAMES-ONLY
+	IndependentSegments bool
+	Closed              bool // is this VOD (closed) or Live (sliding) playlist?
+	MediaType           MediaType
+	durationAsInt       bool // output durations as integers of floats?
+	keyformat           int
+	winsize             uint // max number of segments displayed in an encoded playlist; need set to zero for VOD playlists
+	capacity            uint // total capacity of slice used for the playlist
+	head                uint // head of FIFO, we add segments to head
+	tail                uint // tail of FIFO, we remove segments from tail
+	count               uint // number of segments added to the playlist
+	buf                 bytes.Buffer
+	ver                 uint8
+	Key                 *Key // EXT-X-KEY is optional encryption key displayed before any segments (default key for the playlist)
+	Map                 *Map // EXT-X-MAP is optional tag specifies how to obtain the Media Initialization Section (default map for the playlist)
+	WV                  *WV  // Widevine related tags outside of M3U8 specs
 }
 
 /*

--- a/writer.go
+++ b/writer.go
@@ -337,6 +337,11 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 	p.buf.WriteString("#EXTM3U\n#EXT-X-VERSION:")
 	p.buf.WriteString(strver(p.ver))
 	p.buf.WriteRune('\n')
+
+	if p.IndependentSegments { // Added in HLS Version 6
+		p.buf.WriteString("#EXT-X-INDEPENDENT-SEGMENTS\n")
+	}
+
 	// default key (workaround for Widevine)
 	if p.Key != nil {
 		p.buf.WriteString("#EXT-X-KEY:")
@@ -390,7 +395,11 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 	p.buf.WriteString(strconv.FormatUint(p.SeqNo, 10))
 	p.buf.WriteRune('\n')
 	p.buf.WriteString("#EXT-X-TARGETDURATION:")
-	p.buf.WriteString(strconv.FormatInt(int64(math.Ceil(p.TargetDuration)), 10)) // due section 3.4.2 of M3U8 specs EXT-X-TARGETDURATION must be integer
+	if p.IndependentSegments {
+		p.buf.WriteString(strconv.FormatInt(int64(6), 10))
+	} else {
+		p.buf.WriteString(strconv.FormatInt(int64(math.Ceil(p.TargetDuration)), 10)) // due section 3.4.2 of M3U8 specs EXT-X-TARGETDURATION must be integer
+	}
 	p.buf.WriteRune('\n')
 	if p.Iframe {
 		p.buf.WriteString("#EXT-X-I-FRAMES-ONLY\n")

--- a/writer.go
+++ b/writer.go
@@ -172,6 +172,10 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 		} else {
 			p.buf.WriteString("#EXT-X-STREAM-INF:PROGRAM-ID=")
 			p.buf.WriteString(strconv.FormatUint(uint64(pl.ProgramId), 10))
+			if pl.AverageBandwidth > 0 {
+				p.buf.WriteString(",AVERAGE-BANDWIDTH=")
+				p.buf.WriteString(strconv.FormatUint(uint64(pl.AverageBandwidth), 10))
+			}
 			p.buf.WriteString(",BANDWIDTH=")
 			p.buf.WriteString(strconv.FormatUint(uint64(pl.Bandwidth), 10))
 			if pl.Codecs != "" {

--- a/writer.go
+++ b/writer.go
@@ -395,11 +395,7 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 	p.buf.WriteString(strconv.FormatUint(p.SeqNo, 10))
 	p.buf.WriteRune('\n')
 	p.buf.WriteString("#EXT-X-TARGETDURATION:")
-	if p.IndependentSegments {
-		p.buf.WriteString(strconv.FormatInt(int64(6), 10))
-	} else {
-		p.buf.WriteString(strconv.FormatInt(int64(math.Ceil(p.TargetDuration)), 10)) // due section 3.4.2 of M3U8 specs EXT-X-TARGETDURATION must be integer
-	}
+	p.buf.WriteString(strconv.FormatInt(int64(math.Ceil(p.TargetDuration)), 10)) // due section 3.4.2 of M3U8 specs EXT-X-TARGETDURATION must be integer
 	p.buf.WriteRune('\n')
 	if p.Iframe {
 		p.buf.WriteString("#EXT-X-I-FRAMES-ONLY\n")


### PR DESCRIPTION
Hello,

Thank you for creating and maintaining this great library. I've been using it in an HLS server and ended up making a fork a while back to add a few new attributes to the library. One was EXT-X-INDEPENDENT-SEGMENTS which I think I added because the validator tool was telling me my media playlists needed them.

I also added support for the average bandwidth attribute for each variant in the master playlist, since I was seeing some playlists generated which had this average bandwidth property, and didn't see it in the library.

These changes were rough and just for my own use so let me know if there's any additional work that needs to be done before these attributes could be incorporated into the main codebase.

Thanks again!
Omar Qazi