### PR TITLE
Add support for "m3u+"

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -464,13 +464,13 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 		if state.attributes != nil && len(state.attributes) > 0 {
 			attributes := make([]*Attribute, len(state.attributes))
 			copy(attributes, state.attributes)
-			p.Segments[p.last()].Attributes = &attributes
+			p.Segments[p.last()].Attributes = attributes
 			state.alternatives = nil
 		} else {
 			currSegment := p.Segments[p.last()]
 			if currSegment != nil {
 				attributes := make([]*Attribute, len(state.attributes))
-				currSegment.Attributes = &attributes
+				currSegment.Attributes = attributes
 			}
 		}
 	// start tag first

--- a/reader.go
+++ b/reader.go
@@ -801,7 +801,7 @@ func parseKeyPairs(attrline string) ([]*Attribute, string, int, error) {
 		}
 
 		if state == "duration" {
-			if (c >= 48 && c <= 57) || (c == '.' && strings.Index(duration, ".") == -1) {
+			if (c >= 48 && c <= 57) || c == '.' || c == '-' {
 				duration += string(c)
 				continue
 			}

--- a/reader.go
+++ b/reader.go
@@ -471,8 +471,11 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 			p.Segments[p.last()].Attributes = &attributes
 			state.alternatives = nil
 		} else {
-			attributes := make([]*Attribute, len(state.attributes))
-			p.Segments[p.last()].Attributes = &attributes
+			currSegment := p.Segments[p.last()]
+			if currSegment != nil {
+				attributes := make([]*Attribute, len(state.attributes))
+				currSegment.Attributes = &attributes
+			}
 		}
 	// start tag first
 	case line == "#EXTM3U":

--- a/reader.go
+++ b/reader.go
@@ -471,7 +471,8 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 			p.Segments[p.last()].Attributes = &attributes
 			state.alternatives = nil
 		} else {
-			p.Segments[p.last()].Attributes = &[]*Attribute{}
+			attributes := make([]*Attribute, len(state.attributes))
+			p.Segments[p.last()].Attributes = &attributes
 		}
 	// start tag first
 	case line == "#EXTM3U":
@@ -755,13 +756,13 @@ func parseKeyPairs(attrline string) ([]*Attribute, error) {
 			continue
 		}
 
-		if (escapeNext) {
+		if escapeNext {
 			current.Key += string(c)
 			escapeNext = false
 			continue
 		}
 
-		if (c == '\\') {
+		if c == '\\' {
 			escapeNext = true
 			continue
 		}
@@ -780,7 +781,7 @@ func parseKeyPairs(attrline string) ([]*Attribute, error) {
 				attributes = append(attributes, current)
 				current.Key = ""
 				state = "start"
-			} else if c == '='{
+			} else if c == '=' {
 				state = "value"
 			} else {
 				current.Key += string(c)

--- a/reader_test.go
+++ b/reader_test.go
@@ -369,15 +369,21 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: attributes}},
 		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: attributes}},
 		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: attributes}},
+		{true, "#EXTINF:-1,Title,Track", false, &MediaSegment{Duration: -1, Title: "Title,Track", Attributes: attributes}},
+		{true, "#EXTINF:-1-,Title,Track", true, nil},
 		{true, "#EXTINF:invalid,", true, nil},
 		{true, "#EXTINF:10.000", true, nil},
+		{true, "#EXTINF:10.0.00", true, nil},
 
 		// strict mode off
 		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: attributes}},
 		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: attributes}},
 		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: attributes}},
+		{false, "#EXTINF:-1,Title,Track", false, &MediaSegment{Duration: -1, Title: "Title,Track", Attributes: attributes}},
+		{false, "#EXTINF:-1-,Title,Track", false, &MediaSegment{Duration: 0.0, Title: "Title,Track", Attributes: attributes}},
 		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: "", Attributes: attributes}},
 		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: attributes}},
+		{false, "#EXTINF:10.0.00", false, &MediaSegment{Duration: 0.0, Title: "", Attributes: attributes}},
 	}
 
 	for _, test := range tests {

--- a/reader_test.go
+++ b/reader_test.go
@@ -366,18 +366,18 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 		wantSegment *MediaSegment
 	}{
 		// strict mode on
-		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "",Attributes: &attributes}},
-		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title",Attributes: &attributes}},
-		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track",Attributes: &attributes}},
+		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: &attributes}},
+		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: &attributes}},
+		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: &attributes}},
 		{true, "#EXTINF:invalid,", true, nil},
 		{true, "#EXTINF:10.000", true, nil},
 
 		// strict mode off
-		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "",Attributes: &attributes}},
-		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title",Attributes: &attributes}},
-		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track",Attributes: &attributes}},
-		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: "",Attributes: &attributes}},
-		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: "",Attributes: &attributes}},
+		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: &attributes}},
+		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: &attributes}},
+		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: &attributes}},
+		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: "", Attributes: &attributes}},
+		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: &attributes}},
 	}
 
 	for _, test := range tests {

--- a/reader_test.go
+++ b/reader_test.go
@@ -146,9 +146,9 @@ func TestDecodeMediaPlaylistByteRange(t *testing.T) {
 	_ = p.DecodeFrom(bufio.NewReader(f), true)
 	attributes := make([]*Attribute, 0)
 	expected := []*MediaSegment{
-		{URI: "video.ts", Duration: 10, Limit: 75232, SeqId: 0, Attributes: &attributes},
-		{URI: "video.ts", Duration: 10, Limit: 82112, Offset: 752321, SeqId: 1, Attributes: &attributes},
-		{URI: "video.ts", Duration: 10, Limit: 69864, SeqId: 2, Attributes: &attributes},
+		{URI: "video.ts", Duration: 10, Limit: 75232, SeqId: 0, Attributes: attributes},
+		{URI: "video.ts", Duration: 10, Limit: 82112, Offset: 752321, SeqId: 1, Attributes: attributes},
+		{URI: "video.ts", Duration: 10, Limit: 69864, SeqId: 2, Attributes: attributes},
 	}
 	for i, seg := range p.Segments {
 		if !reflect.DeepEqual(seg, expected[i]) {
@@ -338,10 +338,10 @@ func TestDecodeMediaPlaylistWithAttributes(t *testing.T) {
 		}
 
 		expectedAttributeForSegment := expectedAttributes[s.Title]
-		if len(*s.Attributes) != len(expectedAttributeForSegment) {
-			t.Errorf("Segment %v's attr length = %d (must = %d)", i, len(*s.Attributes), len(expectedAttributeForSegment))
+		if len(s.Attributes) != len(expectedAttributeForSegment) {
+			t.Errorf("Segment %v's attr length = %d (must = %d)", i, len(s.Attributes), len(expectedAttributeForSegment))
 		}
-		for _, attr := range *s.Attributes {
+		for _, attr := range s.Attributes {
 			expectedValue := expectedAttributeForSegment[attr.Key]
 			if attr.Value != expectedValue {
 				t.Errorf("Segment %v's attr %s = %v (must = %q)", i, attr.Key, attr.Value, expectedValue)
@@ -366,18 +366,18 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 		wantSegment *MediaSegment
 	}{
 		// strict mode on
-		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: &attributes}},
-		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: &attributes}},
-		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: &attributes}},
+		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: attributes}},
+		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: attributes}},
+		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: attributes}},
 		{true, "#EXTINF:invalid,", true, nil},
 		{true, "#EXTINF:10.000", true, nil},
 
 		// strict mode off
-		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: &attributes}},
-		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: &attributes}},
-		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: &attributes}},
-		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: "", Attributes: &attributes}},
-		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: &attributes}},
+		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: attributes}},
+		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title", Attributes: attributes}},
+		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track", Attributes: attributes}},
+		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: "", Attributes: attributes}},
+		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: "", Attributes: attributes}},
 	}
 
 	for _, test := range tests {

--- a/reader_test.go
+++ b/reader_test.go
@@ -144,13 +144,14 @@ func TestDecodeMediaPlaylistByteRange(t *testing.T) {
 	f, _ := os.Open("sample-playlists/media-playlist-with-byterange.m3u8")
 	p, _ := NewMediaPlaylist(3, 3)
 	_ = p.DecodeFrom(bufio.NewReader(f), true)
+	attributes := make([]*Attribute, 0)
 	expected := []*MediaSegment{
-		{URI: "video.ts", Duration: 10, Limit: 75232, SeqId: 0},
-		{URI: "video.ts", Duration: 10, Limit: 82112, Offset: 752321, SeqId: 1},
-		{URI: "video.ts", Duration: 10, Limit: 69864, SeqId: 2},
+		{URI: "video.ts", Duration: 10, Limit: 75232, SeqId: 0, Attributes: &attributes},
+		{URI: "video.ts", Duration: 10, Limit: 82112, Offset: 752321, SeqId: 1, Attributes: &attributes},
+		{URI: "video.ts", Duration: 10, Limit: 69864, SeqId: 2, Attributes: &attributes},
 	}
 	for i, seg := range p.Segments {
-		if *seg != *expected[i] {
+		if !reflect.DeepEqual(seg, expected[i]) {
 			t.Errorf("exp: %+v\ngot: %+v", expected[i], seg)
 		}
 	}
@@ -348,6 +349,7 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 %s
 `
 
+	attributes := make([]*Attribute, 0)
 	tests := []struct {
 		strict      bool
 		extInf      string
@@ -355,18 +357,18 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 		wantSegment *MediaSegment
 	}{
 		// strict mode on
-		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: ""}},
-		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title"}},
-		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track"}},
+		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "",Attributes: &attributes}},
+		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title",Attributes: &attributes}},
+		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track",Attributes: &attributes}},
 		{true, "#EXTINF:invalid,", true, nil},
 		{true, "#EXTINF:10.000", true, nil},
 
 		// strict mode off
-		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: ""}},
-		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title"}},
-		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track"}},
-		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: ""}},
-		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: ""}},
+		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: "",Attributes: &attributes}},
+		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title",Attributes: &attributes}},
+		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track",Attributes: &attributes}},
+		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: "",Attributes: &attributes}},
+		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: "",Attributes: &attributes}},
 	}
 
 	for _, test := range tests {

--- a/sample-playlists/media-playlist-with-attributes.m3u8
+++ b/sample-playlists/media-playlist-with-attributes.m3u8
@@ -1,0 +1,8 @@
+#EXTM3U
+#EXTINF:10.000 tvg-id="BBC",BBC
+media0.ts
+#EXTINF:10.000 tvg-id="ITV",ITV
+media1.ts
+#EXTINF:10.000 ,Channel 4
+media2.ts
+#EXT-X-ENDLIST

--- a/sample-playlists/media-playlist-with-attributes.m3u8
+++ b/sample-playlists/media-playlist-with-attributes.m3u8
@@ -5,4 +5,6 @@ media0.ts
 media1.ts
 #EXTINF:10.000 ,Channel 4
 media2.ts
+#EXTINF:10.000 tvg-id="Stream4" tvg-logo="data:image/png;base64,YQo=" group-title="Stream4",Stream4
+media3.ts
 #EXT-X-ENDLIST

--- a/structure.go
+++ b/structure.go
@@ -195,17 +195,17 @@ type Alternative struct {
 // Widevine supports own tags for encryption metadata.
 type MediaSegment struct {
 	SeqId           uint64
-	Title           string       // optional second parameter for EXTINF tag
+	Title           string // optional second parameter for EXTINF tag
 	URI             string
-	Duration        float64      // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
-	Attributes 		*[]*Attribute   // Optional attributes when in non-strict mode (also known as m3u+)
-	Limit           int64        // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
-	Offset          int64        // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
-	Key             *Key         // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
-	Map             *Map         // EXT-X-MAP displayed before the segment
-	Discontinuity   bool         // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
-	SCTE            *SCTE        // SCTE-35 used for Ad signaling in HLS
-	ProgramDateTime time.Time    // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
+	Duration        float64 // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
+	Attributes 		*[]*Attribute // Optional attributes when in non-strict mode (also known as m3u+)
+	Limit           int64 // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
+	Offset          int64 // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
+	Key             *Key // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
+	Map             *Map // EXT-X-MAP displayed before the segment
+	Discontinuity   bool // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
+	SCTE            *SCTE // SCTE-35 used for Ad signaling in HLS
+	ProgramDateTime time.Time // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
 }
 
 // SCTE holds custom, non EXT-X-DATERANGE, SCTE-35 tags

--- a/structure.go
+++ b/structure.go
@@ -198,7 +198,7 @@ type MediaSegment struct {
 	Title           string // optional second parameter for EXTINF tag
 	URI             string
 	Duration        float64       // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
-	Attributes      *[]*Attribute // Optional attributes when in non-strict mode (also known as m3u+)
+	Attributes      []*Attribute  // Optional attributes when in non-strict mode (also known as m3u+)
 	Limit           int64         // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
 	Offset          int64         // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
 	Key             *Key          // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)

--- a/structure.go
+++ b/structure.go
@@ -195,16 +195,17 @@ type Alternative struct {
 // Widevine supports own tags for encryption metadata.
 type MediaSegment struct {
 	SeqId           uint64
-	Title           string // optional second parameter for EXTINF tag
+	Title           string       // optional second parameter for EXTINF tag
 	URI             string
-	Duration        float64   // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
-	Limit           int64     // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
-	Offset          int64     // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
-	Key             *Key      // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
-	Map             *Map      // EXT-X-MAP displayed before the segment
-	Discontinuity   bool      // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
-	SCTE            *SCTE     // SCTE-35 used for Ad signaling in HLS
-	ProgramDateTime time.Time // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
+	Duration        float64      // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
+	Attributes 		*[]*Attribute   // Optional attributes when in non-strict mode (also known as m3u+)
+	Limit           int64        // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
+	Offset          int64        // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
+	Key             *Key         // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
+	Map             *Map         // EXT-X-MAP displayed before the segment
+	Discontinuity   bool         // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
+	SCTE            *SCTE        // SCTE-35 used for Ad signaling in HLS
+	ProgramDateTime time.Time    // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
 }
 
 // SCTE holds custom, non EXT-X-DATERANGE, SCTE-35 tags
@@ -270,6 +271,11 @@ type Playlist interface {
 	String() string
 }
 
+type Attribute struct {
+	Key   string
+	Value string
+}
+
 // Internal structure for decoding a line of input stream with a list type detection
 type decodingState struct {
 	listType           ListType
@@ -293,4 +299,5 @@ type decodingState struct {
 	xkey               *Key
 	xmap               *Map
 	scte               *SCTE
+	attributes         []*Attribute
 }

--- a/structure.go
+++ b/structure.go
@@ -197,15 +197,15 @@ type MediaSegment struct {
 	SeqId           uint64
 	Title           string // optional second parameter for EXTINF tag
 	URI             string
-	Duration        float64 // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
-	Attributes 		*[]*Attribute // Optional attributes when in non-strict mode (also known as m3u+)
-	Limit           int64 // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
-	Offset          int64 // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
-	Key             *Key // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
-	Map             *Map // EXT-X-MAP displayed before the segment
-	Discontinuity   bool // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
-	SCTE            *SCTE // SCTE-35 used for Ad signaling in HLS
-	ProgramDateTime time.Time // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
+	Duration        float64       // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
+	Attributes      *[]*Attribute // Optional attributes when in non-strict mode (also known as m3u+)
+	Limit           int64         // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
+	Offset          int64         // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
+	Key             *Key          // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
+	Map             *Map          // EXT-X-MAP displayed before the segment
+	Discontinuity   bool          // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
+	SCTE            *SCTE         // SCTE-35 used for Ad signaling in HLS
+	ProgramDateTime time.Time     // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
 }
 
 // SCTE holds custom, non EXT-X-DATERANGE, SCTE-35 tags

--- a/structure.go
+++ b/structure.go
@@ -197,15 +197,15 @@ type MediaSegment struct {
 	SeqId           uint64
 	Title           string // optional second parameter for EXTINF tag
 	URI             string
-	Duration        float64       // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
-	Attributes      []*Attribute  // Optional attributes when in non-strict mode (also known as m3u+)
-	Limit           int64         // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
-	Offset          int64         // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
-	Key             *Key          // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
-	Map             *Map          // EXT-X-MAP displayed before the segment
-	Discontinuity   bool          // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
-	SCTE            *SCTE         // SCTE-35 used for Ad signaling in HLS
-	ProgramDateTime time.Time     // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
+	Duration        float64      // first parameter for EXTINF tag; duration must be integers if protocol version is less than 3 but we are always keep them float
+	Attributes      []*Attribute // Optional attributes when in non-strict mode (also known as m3u+)
+	Limit           int64        // EXT-X-BYTERANGE <n> is length in bytes for the file under URI
+	Offset          int64        // EXT-X-BYTERANGE [@o] is offset from the start of the file under URI
+	Key             *Key         // EXT-X-KEY displayed before the segment and means changing of encryption key (in theory each segment may have own key)
+	Map             *Map         // EXT-X-MAP displayed before the segment
+	Discontinuity   bool         // EXT-X-DISCONTINUITY indicates an encoding discontinuity between the media segment that follows it and the one that preceded it (i.e. file format, number and type of tracks, encoding parameters, encoding sequence, timestamp sequence)
+	SCTE            *SCTE        // SCTE-35 used for Ad signaling in HLS
+	ProgramDateTime time.Time    // EXT-X-PROGRAM-DATE-TIME tag associates the first sample of a media segment with an absolute date and/or time
 }
 
 // SCTE holds custom, non EXT-X-DATERANGE, SCTE-35 tags

--- a/writer.go
+++ b/writer.go
@@ -628,6 +628,15 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 			}
 			p.buf.WriteString(durationCache[seg.Duration])
 		}
+		if len(seg.Attributes) > 0 {
+			p.buf.WriteRune(' ')
+			for _, attribute := range seg.Attributes {
+				p.buf.WriteString(attribute.Key)
+				p.buf.WriteRune('=')
+				p.buf.WriteString(strconv.Quote(attribute.Value))
+
+			}
+		}
 		p.buf.WriteRune(',')
 		p.buf.WriteString(seg.Title)
 		p.buf.WriteRune('\n')

--- a/writer.go
+++ b/writer.go
@@ -629,12 +629,11 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 			p.buf.WriteString(durationCache[seg.Duration])
 		}
 		if len(seg.Attributes) > 0 {
-			p.buf.WriteRune(' ')
 			for _, attribute := range seg.Attributes {
+				p.buf.WriteRune(' ')
 				p.buf.WriteString(attribute.Key)
 				p.buf.WriteRune('=')
 				p.buf.WriteString(strconv.Quote(attribute.Value))
-
 			}
 		}
 		p.buf.WriteRune(',')

--- a/writer_test.go
+++ b/writer_test.go
@@ -482,15 +482,15 @@ func TestMediaPlaylistWithAttributes(t *testing.T) {
 	if e != nil {
 		t.Fatalf("Create media playlist failed: %s", e)
 	}
-	e = p.AppendSegment(&MediaSegment{Title: "test1", URI:"media1.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-id", Value: "id",}},})
+	e = p.AppendSegment(&MediaSegment{Title: "test1", URI: "media1.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-id", Value: "id"}}})
 	if e != nil {
 		t.Errorf("Add segment 1 to a media playlist failed: %s", e)
 	}
-	e = p.AppendSegment(&MediaSegment{Title: "test2", URI:"media2.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-logo", Value: "data:image/png;base64,YQo=",}},})
+	e = p.AppendSegment(&MediaSegment{Title: "test2", URI: "media2.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-logo", Value: "data:image/png;base64,YQo="}}})
 	if e != nil {
 		t.Errorf("Add segment 2 to a media playlist failed: %s", e)
 	}
-	e = p.AppendSegment(&MediaSegment{Title: "test3", URI:"media3.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-name", Value: `quoted"test`}}})
+	e = p.AppendSegment(&MediaSegment{Title: "test3", URI: "media3.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-name", Value: `quoted"test`}}})
 	if e != nil {
 		t.Errorf("Add segment 3 to a media playlist failed: %s", e)
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -475,6 +475,42 @@ func TestMediaPlaylistWithIntegerDurations(t *testing.T) {
 }
 
 // Create new media playlist
+// Add 10 segments to media playlist
+// Encode structure to HLS with integer target durations
+func TestMediaPlaylistWithAttributes(t *testing.T) {
+	p, e := NewMediaPlaylist(3, 10)
+	if e != nil {
+		t.Fatalf("Create media playlist failed: %s", e)
+	}
+	e = p.AppendSegment(&MediaSegment{Title: "test1", URI:"media1.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-id", Value: "id",}},})
+	if e != nil {
+		t.Errorf("Add segment 1 to a media playlist failed: %s", e)
+	}
+	e = p.AppendSegment(&MediaSegment{Title: "test2", URI:"media2.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-logo", Value: "data:image/png;base64,YQo=",}},})
+	if e != nil {
+		t.Errorf("Add segment 2 to a media playlist failed: %s", e)
+	}
+	e = p.AppendSegment(&MediaSegment{Title: "test3", URI:"media3.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-name", Value: `quoted"test`}}})
+	if e != nil {
+		t.Errorf("Add segment 3 to a media playlist failed: %s", e)
+	}
+
+	expected := `#EXTINF:10.000 tvg-id="id",test1`
+	if !strings.Contains(p.String(), expected) {
+		t.Errorf("Manifest '%+v' did not contain expected '%+v'", p, expected)
+	}
+	expected = `#EXTINF:10.000 tvg-logo="data:image/png;base64,YQo=",test2`
+	if !strings.Contains(p.String(), expected) {
+		t.Errorf("Manifest '%+v' did not contain expected '%+v'", p, expected)
+	}
+	expected = `#EXTINF:10.000 tvg-name="quoted\"test",test3`
+	if !strings.Contains(p.String(), expected) {
+		t.Errorf("Manifest '%+v' did not contain expected '%+v'", p, expected)
+	}
+	fmt.Println(p.Encode().String())
+}
+
+// Create new media playlist
 // Add 9 segments to media playlist
 // 11 times encode structure to HLS with integer target durations
 // Last playlist must be empty

--- a/writer_test.go
+++ b/writer_test.go
@@ -507,7 +507,7 @@ func TestMediaPlaylistWithAttributes(t *testing.T) {
 	if !strings.Contains(p.String(), expected) {
 		t.Errorf("Manifest '%+v' did not contain expected '%+v'", p, expected)
 	}
-	fmt.Println(p.Encode().String())
+	//fmt.Println(p.Encode().String())
 }
 
 // Create new media playlist

--- a/writer_test.go
+++ b/writer_test.go
@@ -490,7 +490,7 @@ func TestMediaPlaylistWithAttributes(t *testing.T) {
 	if e != nil {
 		t.Errorf("Add segment 2 to a media playlist failed: %s", e)
 	}
-	e = p.AppendSegment(&MediaSegment{Title: "test3", URI: "media3.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-name", Value: `quoted"test`}}})
+	e = p.AppendSegment(&MediaSegment{Title: "test3", URI: "media3.ts", Duration: 10, Attributes: []*Attribute{{Key: "tvg-id", Value: `id`}, {Key: "tvg-name", Value: `quoted"test`}}})
 	if e != nil {
 		t.Errorf("Add segment 3 to a media playlist failed: %s", e)
 	}
@@ -503,7 +503,7 @@ func TestMediaPlaylistWithAttributes(t *testing.T) {
 	if !strings.Contains(p.String(), expected) {
 		t.Errorf("Manifest '%+v' did not contain expected '%+v'", p, expected)
 	}
-	expected = `#EXTINF:10.000 tvg-name="quoted\"test",test3`
+	expected = `#EXTINF:10.000 tvg-id="id" tvg-name="quoted\"test",test3`
 	if !strings.Contains(p.String(), expected) {
 		t.Errorf("Manifest '%+v' did not contain expected '%+v'", p, expected)
 	}


### PR DESCRIPTION
This add support for m3u+. Which should close #82

I've made it fail when `strict=true` since, from what I could tell, this is not part of the spec.

Let me know what you guys think.  