### PR TITLE
fix: add new line after #EXT-X-DISCONTINUITY-SEQUENCE

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -421,6 +421,7 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 	if p.DiscontinuitySeq != 0 {
 		p.buf.WriteString("#EXT-X-DISCONTINUITY-SEQUENCE:")
 		p.buf.WriteString(strconv.FormatUint(uint64(p.DiscontinuitySeq), 10))
+		p.buf.WriteRune('\n')
 	}
 	if p.Iframe {
 		p.buf.WriteString("#EXT-X-I-FRAMES-ONLY\n")


### PR DESCRIPTION
When rendering a mediaplaylist with a DiscontinuitySeq different than 0 a new line is missing, so is being displayed as:

```
#EXTM3U
#EXT-X-VERSION:6
#EXT-X-MEDIA-SEQUENCE:15150186350000
#EXT-X-TARGETDURATION:2
#EXT-X-DISCONTINUITY-SEQUENCE:1#EXTINF:2.000,
```

instead of: 
```
#EXTM3U
#EXT-X-VERSION:6
#EXT-X-MEDIA-SEQUENCE:15150186350000
#EXT-X-TARGETDURATION:2
#EXT-X-DISCONTINUITY-SEQUENCE:1
#EXTINF:2.000,
```