### PR TITLE
Correctly handle TIME-OFFSET according to spec

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -612,7 +612,7 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 				if err != nil {
 					return fmt.Errorf("Invalid TIME-OFFSET: %s: %v", v, err)
 				}
-				p.StartTime = st
+				p.StartTime = &st
 			case "PRECISE":
 				p.StartTimePrecise = v == "YES"
 			}

--- a/reader_test.go
+++ b/reader_test.go
@@ -973,8 +973,9 @@ func TestDecodeMediaPlaylistStartTime(t *testing.T) {
 	if listType != MEDIA {
 		t.Error("Sample not recognized as media playlist.")
 	}
-	if pp.StartTime != float64(8.0) {
-		t.Errorf("Media segment StartTime != 8: %f", pp.StartTime)
+	startTime := float64(8.0)
+	if *pp.StartTime != startTime {
+		t.Errorf("Media segment StartTime != 8: %f", *pp.StartTime)
 	}
 }
 

--- a/structure.go
+++ b/structure.go
@@ -110,7 +110,7 @@ type MediaPlaylist struct {
 	Closed           bool   // is this VOD (closed) or Live (sliding) playlist?
 	MediaType        MediaType
 	DiscontinuitySeq uint64 // EXT-X-DISCONTINUITY-SEQUENCE
-	StartTime        float64
+	StartTime        *float64
 	StartTimePrecise bool
 	durationAsInt    bool // output durations as integers of floats?
 	keyformat        int

--- a/writer.go
+++ b/writer.go
@@ -469,9 +469,9 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 	p.buf.WriteString("#EXT-X-TARGETDURATION:")
 	p.buf.WriteString(strconv.FormatInt(int64(math.Ceil(p.TargetDuration)), 10)) // due section 3.4.2 of M3U8 specs EXT-X-TARGETDURATION must be integer
 	p.buf.WriteRune('\n')
-	if p.StartTime > 0.0 {
+	if p.StartTime != nil {
 		p.buf.WriteString("#EXT-X-START:TIME-OFFSET=")
-		p.buf.WriteString(strconv.FormatFloat(p.StartTime, 'f', -1, 64))
+		p.buf.WriteString(strconv.FormatFloat(*p.StartTime, 'f', -1, 64))
 		if p.StartTimePrecise {
 			p.buf.WriteString(",PRECISE=YES")
 		}

--- a/writer_test.go
+++ b/writer_test.go
@@ -680,7 +680,9 @@ func TestStartTimeOffset(t *testing.T) {
 	if e != nil {
 		t.Fatalf("Create media playlist failed: %s", e)
 	}
-	p.StartTime = 3.4
+
+	startTime := 3.4
+	p.StartTime = &startTime
 
 	expected := `#EXT-X-START:TIME-OFFSET=3.4`
 	if !strings.Contains(p.String(), expected) {


### PR DESCRIPTION
Spec reference: https://tools.ietf.org/html/rfc8216#section-4.3.5.2

According to the spec, TIME-OFFSET is a `signed-decimal-floating-point number of seconds`, so allowed values can be positive or negative, and can also be 0. (They have different meanings in each case)

With the current implementation of m3u8, TIME-OFFSET is only printed when its value is > 0

- This PR changes the type of `StartTime` from `float64` to `*float64` to differentiate between `0.0` and `nil` value
- The TIME-OFFSET will be printed if `StartTime != nil`