### PR TITLE
Add AllowCache option to MediaPlaylist

### DIFF
--- a/structure.go
+++ b/structure.go
@@ -107,7 +107,7 @@ type MediaPlaylist struct {
 	Segments         []*MediaSegment
 	Args             string // optional arguments placed after URIs (URI?Args)
 	Iframe           bool   // EXT-X-I-FRAMES-ONLY
-	AllowCache	 bool	// EXT-X-ALLOW-CACHE
+	AllowCache       bool   // EXT-X-ALLOW-CACHE
 	Closed           bool   // is this VOD (closed) or Live (sliding) playlist?
 	MediaType        MediaType
 	DiscontinuitySeq uint64 // EXT-X-DISCONTINUITY-SEQUENCE

--- a/structure.go
+++ b/structure.go
@@ -107,6 +107,7 @@ type MediaPlaylist struct {
 	Segments         []*MediaSegment
 	Args             string // optional arguments placed after URIs (URI?Args)
 	Iframe           bool   // EXT-X-I-FRAMES-ONLY
+	AllowCache	 bool	// EXT-X-ALLOW-CACHE
 	Closed           bool   // is this VOD (closed) or Live (sliding) playlist?
 	MediaType        MediaType
 	DiscontinuitySeq uint64 // EXT-X-DISCONTINUITY-SEQUENCE

--- a/writer.go
+++ b/writer.go
@@ -458,7 +458,9 @@ func (p *MediaPlaylist) Encode() *bytes.Buffer {
 		switch p.MediaType {
 		case EVENT:
 			p.buf.WriteString("EVENT\n")
-			p.buf.WriteString("#EXT-X-ALLOW-CACHE:NO\n")
+			if !p.AllowCache {
+				p.buf.WriteString("#EXT-X-ALLOW-CACHE:NO\n")
+			}
 		case VOD:
 			p.buf.WriteString("VOD\n")
 		}
@@ -762,6 +764,12 @@ func (p *MediaPlaylist) SetDefaultMap(uri string, limit, offset int64) {
 func (p *MediaPlaylist) SetIframeOnly() {
 	version(&p.ver, 4) // due section 4.3.3
 	p.Iframe = true
+}
+
+// SetAllowCache prevents from disabling cache via EXT-X-ALLOW-CACHE:NO tag.
+// Set for the Event MediaType.
+func (p *MediaPlaylist) SetAllowCache() {
+	p.AllowCache = true
 }
 
 // Set encryption key for the current segment of media playlist (pointer to Segment.Key)


### PR DESCRIPTION
Added option prevents from disabling cache via EXT-X-ALLOW-CACHE tag
for Event playlists encodig.