### PR TITLE
Fix FORCED attribute improper quotation

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -136,9 +136,8 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 					p.buf.WriteRune('"')
 				}
 				if alt.Forced != "" {
-					p.buf.WriteString(",FORCED=\"")
+					p.buf.WriteString(",FORCED=")
 					p.buf.WriteString(alt.Forced)
-					p.buf.WriteRune('"')
 				}
 				if alt.Characteristics != "" {
 					p.buf.WriteString(",CHARACTERISTICS=\"")


### PR DESCRIPTION
The FORCED attribute is not a quoted-string. From the RFC:

> The value is an enumerated-string; valid strings are YES and NO.