### PR TITLE
Declare errors to make easier for callers to detect

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -22,6 +22,12 @@ import (
 	"time"
 )
 
+// The #EXTM3U directive was not found
+var ErrExtM3uAbsent = fmt.Errorf("#EXTM3U was not found")
+
+// The playlist type could not be detected
+var ErrUnknownPlaylistType = fmt.Errorf("Can't detect playlist type")
+
 var reKeyValue = regexp.MustCompile(`([a-zA-Z0-9_-]+)=("[^"]+"|[^",]+)`)
 
 // TimeParse allows globally apply and/or override Time Parser function.
@@ -79,7 +85,7 @@ func (p *MasterPlaylist) decode(buf *bytes.Buffer, strict bool) error {
 		}
 	}
 	if strict && !state.m3u {
-		return errors.New("#EXTM3U absent")
+		return ErrExtM3uAbsent
 	}
 	return nil
 }
@@ -139,7 +145,7 @@ func (p *MediaPlaylist) decode(buf *bytes.Buffer, strict bool) error {
 		p.WV = wv
 	}
 	if strict && !state.m3u {
-		return errors.New("#EXTM3U absent")
+		return ErrExtM3uAbsent
 	}
 	return nil
 }
@@ -235,7 +241,7 @@ func decode(buf *bytes.Buffer, strict bool, customDecoders []CustomDecoder) (Pla
 	}
 
 	if strict && !state.m3u {
-		return nil, listType, errors.New("#EXTM3U absent")
+		return nil, listType, ErrExtM3uAbsent
 	}
 
 	switch state.listType {
@@ -248,7 +254,7 @@ func decode(buf *bytes.Buffer, strict bool, customDecoders []CustomDecoder) (Pla
 		}
 		return media, MEDIA, nil
 	}
-	return nil, state.listType, errors.New("Can't detect playlist type")
+	return nil, state.listType, ErrUnknownPlaylistType
 }
 
 // DecodeAttributeList turns an attribute list into a key, value map. You should trim

--- a/writer.go
+++ b/writer.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ErrPlaylistFull declares the playlist error.
-var ErrPlaylistFull = errors.New("playlist is full")
+var ErrPlaylistFull = fmt.Errorf("playlist is full")
 
 // Set version of the playlist accordingly with section 7
 func version(ver *uint8, newver uint8) {


### PR DESCRIPTION
We've found a few places where it would be nice to be able to handle specific errors without resorting to string processing.