### PR TITLE
Adding Head method to get details of first segment

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -334,6 +334,11 @@ func (p *MediaPlaylist) last() uint {
 	return p.tail - 1
 }
 
+// head returns the first segment's index
+func (p *MediaPlaylist) Head() uint {
+	return p.head
+}
+
 // Remove current segment from the head of chunk slice form a media playlist. Useful for sliding playlists.
 // This operation does reset playlist cache.
 func (p *MediaPlaylist) Remove() (err error) {


### PR DESCRIPTION
In a sliding window playlist, we need to increase disconitnuity sequence number if the first segment of the playlist is removed. Since, there is no method or attribute exposed to get the first segment details, we are not able to obtain discontinuity flag from the it. Exposing a method to get the "head" segment of the playlist.