### PR TITLE
Ignore blank lines in playlist -- fixes panic w/EXT-X-MAP.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -472,6 +472,8 @@ func decodeLineOfMediaPlaylist(p *MediaPlaylist, wv *WV, state *decodingState, l
 	}
 
 	switch {
+	case len(line) == 0:
+		// blank lines are ignored
 	case !state.tagInf && strings.HasPrefix(line, "#EXTINF:"):
 		state.tagInf = true
 		state.listType = MEDIA

--- a/reader_test.go
+++ b/reader_test.go
@@ -344,6 +344,7 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 #EXT-X-VERSION:3
 #EXT-X-MEDIA-SEQUENCE:0
 %s
+/s.ts
 `
 
 	tests := []struct {
@@ -353,18 +354,18 @@ func TestDecodeMediaPlaylistExtInfNonStrict2(t *testing.T) {
 		wantSegment *MediaSegment
 	}{
 		// strict mode on
-		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: ""}},
-		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title"}},
-		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track"}},
+		{true, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, URI: "/s.ts", Title: ""}},
+		{true, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, URI: "/s.ts", Title: "Title"}},
+		{true, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, URI: "/s.ts", Title: "Title,Track"}},
 		{true, "#EXTINF:invalid,", true, nil},
 		{true, "#EXTINF:10.000", true, nil},
 
 		// strict mode off
-		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, Title: ""}},
-		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, Title: "Title"}},
-		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, Title: "Title,Track"}},
-		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, Title: ""}},
-		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, Title: ""}},
+		{false, "#EXTINF:10.000,", false, &MediaSegment{Duration: 10.0, URI: "/s.ts", Title: ""}},
+		{false, "#EXTINF:10.000,Title", false, &MediaSegment{Duration: 10.0, URI: "/s.ts", Title: "Title"}},
+		{false, "#EXTINF:10.000,Title,Track", false, &MediaSegment{Duration: 10.0, URI: "/s.ts", Title: "Title,Track"}},
+		{false, "#EXTINF:invalid,", false, &MediaSegment{Duration: 0.0, URI: "/s.ts", Title: ""}},
+		{false, "#EXTINF:10.000", false, &MediaSegment{Duration: 10.0, URI: "/s.ts", Title: ""}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
reader.go panics if there's a blank line between the header containing EXT-X-MAP and the first segment for FMP4 media playlists. (It tries to add MAP to the first segment, which it hasn't created yet.)

Patch fixes this by ignoring blank lines; reader_test.go updated to work with change (one of the tests assumed prior behavior).

@eric confirms this is consistent with the [standard](https://datatracker.ietf.org/doc/html/rfc8216#section-4.1):

> Lines in a Playlist file are terminated by either a single line feed
> character or a carriage return character followed by a line feed
> character. Each line is a URI, is blank, or starts with the
> character '#'. Blank lines are ignored. Whitespace MUST NOT be
> present, except for elements in which it is explicitly specified.

Issue seems to have been previously reported as #166.