### PR TITLE
thought of how to address "alternatives" to fix inconsistency

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -331,15 +331,11 @@ func decodeLineOfMasterPlaylist(p *MasterPlaylist, state *decodingState, line st
 				alt.URI = v
 			}
 		}
-		state.alternatives = append(state.alternatives, &alt)
+		p.Alternatives = append(p.Alternatives, &alt)
 	case !state.tagStreamInf && strings.HasPrefix(line, "#EXT-X-STREAM-INF:"):
 		state.tagStreamInf = true
 		state.listType = MASTER
 		state.variant = new(Variant)
-		if len(state.alternatives) > 0 {
-			state.variant.Alternatives = state.alternatives
-			state.alternatives = nil
-		}
 		p.Variants = append(p.Variants, state.variant)
 		for k, v := range decodeParamsLine(line[18:]) {
 			switch k {
@@ -395,10 +391,6 @@ func decodeLineOfMasterPlaylist(p *MasterPlaylist, state *decodingState, line st
 		state.listType = MASTER
 		state.variant = new(Variant)
 		state.variant.Iframe = true
-		if len(state.alternatives) > 0 {
-			state.variant.Alternatives = state.alternatives
-			state.alternatives = nil
-		}
 		p.Variants = append(p.Variants, state.variant)
 		for k, v := range decodeParamsLine(line[26:]) {
 			switch k {

--- a/reader_test.go
+++ b/reader_test.go
@@ -85,19 +85,28 @@ func TestDecodeMasterPlaylistWithAlternatives(t *testing.T) {
 		t.Fatal("not all variants in master playlist parsed")
 	}
 	// TODO check other values
-	for i, v := range p.Variants {
-		if i == 0 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
+	var low_count, mid_count, hi_count int
+	for _, a := range p.Alternatives {
+		switch a.GroupId {
+		case "low":
+			low_count++
+			break
+		case "mid":
+			mid_count++
+			break
+		case "hi":
+			hi_count++
+			break
 		}
-		if i == 1 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 2 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
-		}
-		if i == 3 && len(v.Alternatives) > 0 {
-			t.Fatal("should not be alternatives for this variant")
-		}
+	}
+	if low_count != 3 {
+		t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", low_count)
+	}
+	if mid_count != 3 {
+		t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", mid_count)
+	}
+	if hi_count != 3 {
+		t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", hi_count)
 	}
 	// fmt.Println(p.Encode().String())
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -85,7 +85,7 @@ func TestDecodeMasterPlaylistWithAlternatives(t *testing.T) {
 		t.Fatal("not all variants in master playlist parsed")
 	}
 	// TODO check other values
-	var low_count, mid_git count, hi_count int
+	var low_count, mid_count, hi_count int
 	for _, a := range p.Alternatives {
 		switch a.GroupId {
 		case "low":

--- a/reader_test.go
+++ b/reader_test.go
@@ -85,18 +85,15 @@ func TestDecodeMasterPlaylistWithAlternatives(t *testing.T) {
 		t.Fatal("not all variants in master playlist parsed")
 	}
 	// TODO check other values
-	var low_count, mid_count, hi_count int
+	var low_count, mid_git count, hi_count int
 	for _, a := range p.Alternatives {
 		switch a.GroupId {
 		case "low":
 			low_count++
-			break
 		case "mid":
 			mid_count++
-			break
 		case "hi":
 			hi_count++
-			break
 		}
 	}
 	if low_count != 3 {

--- a/structure.go
+++ b/structure.go
@@ -147,8 +147,9 @@ type MediaPlaylist struct {
 //    http://example.com/audio-only.m3u8
 type MasterPlaylist struct {
 	Variants            []*Variant
-	Args                string // optional arguments placed after URI (URI?Args)
-	CypherVersion       string // non-standard tag for Widevine (see also WV struct)
+	Alternatives        []*Alternative // EXT-X-MEDIA
+	Args                string         // optional arguments placed after URI (URI?Args)
+	CypherVersion       string         // non-standard tag for Widevine (see also WV struct)
 	buf                 bytes.Buffer
 	ver                 uint8
 	independentSegments bool
@@ -181,8 +182,7 @@ type VariantParams struct {
 	Iframe           bool   // EXT-X-I-FRAME-STREAM-INF
 	VideoRange       string
 	HDCPLevel        string
-	FrameRate        float64        // EXT-X-STREAM-INF
-	Alternatives     []*Alternative // EXT-X-MEDIA
+	FrameRate        float64 // EXT-X-STREAM-INF
 }
 
 // Alternative structure represents EXT-X-MEDIA tag in variants.
@@ -327,7 +327,6 @@ type decodingState struct {
 	duration           float64
 	title              string
 	variant            *Variant
-	alternatives       []*Alternative
 	xkey               *Key
 	xmap               *Map
 	scte               *SCTE

--- a/writer_test.go
+++ b/writer_test.go
@@ -789,7 +789,8 @@ func TestNewMasterPlaylistWithAlternatives(t *testing.T) {
 			t.Errorf("Add segment #%d to a media playlist failed: %s", i, e)
 		}
 	}
-	m.Append("chunklist1.m3u8", p, VariantParams{Alternatives: []*Alternative{audioAlt}})
+	m.Append("chunklist1.m3u8", p, VariantParams{})
+	m.AppendAlternative(*audioAlt)
 
 	if m.ver != 4 {
 		t.Fatalf("Expected version 4, actual, %d", m.ver)


### PR DESCRIPTION
currently, what m3u8 package calls alternatives seem to be handled inconsistently.  Namely, only the first "variant" after the set of alternatives gets the alternative and if the altneratives are at the end of the file, none get them.